### PR TITLE
fix: fix `@napi-rs/canvas` warning

### DIFF
--- a/packages/file-loaders/package.json
+++ b/packages/file-loaders/package.json
@@ -25,7 +25,6 @@
     "test:coverage": "vitest --coverage --silent='passed-only'"
   },
   "dependencies": {
-    "@napi-rs/canvas": "^0.1.70",
     "@xmldom/xmldom": "^0.9.8",
     "concat-stream": "^2.0.0",
     "debug": "^4.3.4",

--- a/packages/file-loaders/test/setup.ts
+++ b/packages/file-loaders/test/setup.ts
@@ -1,11 +1,3 @@
-// Polyfill DOMMatrix for pdfjs-dist in Node.js environment
-import { DOMMatrix } from '@napi-rs/canvas';
-
-if (typeof global.DOMMatrix === 'undefined') {
-  // @ts-ignore
-  global.DOMMatrix = DOMMatrix;
-}
-
 // Polyfill URL.createObjectURL and URL.revokeObjectURL for pdfjs-dist
 if (typeof global.URL.createObjectURL === 'undefined') {
   global.URL.createObjectURL = () => 'blob:http://localhost/fake-blob-url';


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Sourcery 摘要

移除过时的 DOMMatrix polyfill 和依赖项，以解决 canvas 警告

错误修复:
- 从测试设置中移除 DOMMatrix 导入和全局赋值，以消除 @napi-rs/canvas 警告
- 从 file-loaders 依赖项中移除 @napi-rs/canvas，因为它不再需要

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Remove obsolete DOMMatrix polyfill and dependency to resolve canvas warning

Bug Fixes:
- Remove DOMMatrix import and global assignment from test setup to eliminate @napi-rs/canvas warning
- Remove @napi-rs/canvas from file-loaders dependencies since it’s no longer needed

</details>