### PR TITLE
🐛 fix: fix GroupChat msg send

### DIFF
--- a/src/app/[variants]/(main)/chat/components/conversation/features/ChatInput/useSend.ts
+++ b/src/app/[variants]/(main)/chat/components/conversation/features/ChatInput/useSend.ts
@@ -94,12 +94,14 @@ export const useSend = () => {
 
     if (!shouldContinue) return;
 
+    // Wait for message to be sent before clearing input
     if (params.onlyAddAIMessage) {
-      addAIMessage();
+      await addAIMessage();
     } else {
-      sendMessage({ files: fileList, message: inputMessage, ...params });
+      await sendMessage({ files: fileList, message: inputMessage, ...params });
     }
 
+    // Only clear input after message is successfully sent
     clearChatUploadFileList();
     mainInputEditor.setExpand(false);
     mainInputEditor.clearContent();
@@ -244,7 +246,7 @@ export const useSendGroupMessage = () => {
           : '';
       const messageWithMentions = `${inputMessage}${mentionText}`.trim();
 
-      sendGroupMessage({
+      await sendGroupMessage({
         files: fileList,
         groupId: store.activeId,
         message: messageWithMentions,
@@ -252,6 +254,7 @@ export const useSendGroupMessage = () => {
         ...params,
       });
 
+      // Only clear input after message is successfully sent
       clearChatUploadFileList();
       mainInputEditor.setExpand(false);
       mainInputEditor.clearContent();


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #123, Closes #456, Related to #789 -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## 由 Sourcery 提供的摘要

确保只有在聊天和群组消息成功发送后，才会从输入框中清除内容。

错误修复：
- 修复聊天消息发送逻辑，在发送操作完成之前不清空输入框。
- 修复群组聊天消息发送逻辑，仅在群组消息发送完成后才重置输入内容和附件。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure chat and group messages are only cleared from the input after they are successfully sent.

Bug Fixes:
- Fix chat message sending so the input is not cleared until the send operation completes.
- Fix group chat message sending so the input and attachments are only reset after the group message has been sent.

</details>