### PR TITLE
feat: support `tool_stream` for GLM 4.6 & 4.7

### DIFF
--- a/packages/model-runtime/src/providers/zhipu/index.ts
+++ b/packages/model-runtime/src/providers/zhipu/index.ts
@@ -19,7 +19,7 @@ export const params = {
   baseURL: 'https://open.bigmodel.cn/api/paas/v4',
   chatCompletion: {
     handlePayload: (payload) => {
-      const { enabledSearch, max_tokens, model, temperature, thinking, tools, top_p, ...rest } =
+      const { enabledSearch, max_tokens, model, stream, temperature, thinking, tools, top_p, ...rest } =
         payload;
 
       const zhipuTools = enabledSearch
@@ -60,8 +60,9 @@ export const params = {
         ...rest,
         ...resolvedParams,
         model,
-        stream: true,
+        stream,
         thinking: thinking ? { type: thinking.type } : undefined,
+        tool_stream: stream && /^glm-4\.(6|7)/.test(model) ? true : undefined,
         tools: zhipuTools,
       } as any;
     },

--- a/packages/model-runtime/src/providers/zhipu/index.ts
+++ b/packages/model-runtime/src/providers/zhipu/index.ts
@@ -62,7 +62,7 @@ export const params = {
         model,
         stream,
         thinking: thinking ? { type: thinking.type } : undefined,
-        tool_stream: stream && /^glm-4\.(6|7)/.test(model) ? true : undefined,
+        tool_stream: stream && /^glm-4\.(6|7)$/.test(model) ? true : undefined,
         tools: zhipuTools,
       } as any;
     },


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [X] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

为智谱聊天补全添加可配置的流式支持，并为兼容的 GLM 4.x 模型启用工具流式功能。

新功能：
- 允许调用方控制智谱聊天补全请求中的 `stream` 参数，而不是始终使用流式响应。
- 当请求流式响应时，自动为 GLM 4.6 和 4.7 模型启用 `tool_stream`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add configurable streaming support for Zhipu chat completions and enable tool streaming for compatible GLM 4.x models.

New Features:
- Allow callers to control the stream parameter for Zhipu chat completion requests instead of always streaming responses.
- Automatically enable tool_stream for GLM 4.6 and 4.7 models when streaming is requested.

</details>