### PR TITLE
💄 style: support more qwen i2i or t2i models

### DIFF
--- a/packages/model-bank/src/aiModels/qwen.ts
+++ b/packages/model-bank/src/aiModels/qwen.ts
@@ -1019,7 +1019,8 @@ const qwenChatModels: AIChatModelCard[] = [
       deploymentName: 'qwen-plus-2025-12-01',
     },
     contextWindowTokens: 1_000_000,
-    description: 'Enhanced ultra-large Qwen model supporting Chinese, English, and other languages.',
+    description:
+      'Enhanced ultra-large Qwen model supporting Chinese, English, and other languages.',
     displayName: 'Qwen Plus',
     enabled: true,
     id: 'qwen-plus',
@@ -1477,7 +1478,8 @@ const qwenChatModels: AIChatModelCard[] = [
       vision: true,
     },
     contextWindowTokens: 131_072,
-    description: 'Qwen3 VL 8B non-thinking mode (Instruct) for standard multimodal generation and recognition.',
+    description:
+      'Qwen3 VL 8B non-thinking mode (Instruct) for standard multimodal generation and recognition.',
     displayName: 'Qwen3 VL 8B Instruct',
     id: 'qwen3-vl-8b-instruct',
     maxOutput: 32_768,
@@ -2182,13 +2184,13 @@ const qwenChatModels: AIChatModelCard[] = [
 const qwenImageModels: AIImageModelCard[] = [
   {
     description:
-      'Qwen Image Edit is an image-to-image model that edits images based on input images and text prompts, enabling precise adjustments and creative transformations.',
+      'Z-Image is a lightweight text-to-image generation model that can rapidly produce images, supports both Chinese and English text rendering, and flexibly adapts to multiple resolutions and aspect ratios.',
     displayName: 'Z-Image Turbo',
     enabled: true,
     id: 'z-image-turbo',
     organization: 'Qwen',
     parameters: {
-      height: { default: 1024, max: 2048, min: 512, step: 1 },
+      height: { default: 1536, max: 2048, min: 512, step: 1 },
       prompt: {
         default: '',
       },
@@ -2197,14 +2199,14 @@ const qwenImageModels: AIImageModelCard[] = [
     },
     pricing: {
       currency: 'CNY',
-      units: [{ name: 'imageGeneration', rate: 0.3, strategy: 'fixed', unit: 'image' }],
+      units: [{ name: 'imageGeneration', rate: 0.1, strategy: 'fixed', unit: 'image' }],
     },
-    releasedAt: '2026-01-16',
+    releasedAt: '2025-12-19',
     type: 'image',
   },
   {
     description:
-      'Qwen Image Edit is an image-to-image model that edits images based on input images and text prompts, enabling precise adjustments and creative transformations.',
+      'Qwen Image Editing Model supports multi-image input and multi-image output, enabling precise in-image text editing, object addition, removal, or relocation, subject action modification, image style transfer, and enhanced visual detail.',
     displayName: 'Qwen Image Edit Max',
     enabled: true,
     id: 'qwen-image-edit-max',
@@ -2220,14 +2222,14 @@ const qwenImageModels: AIImageModelCard[] = [
     },
     pricing: {
       currency: 'CNY',
-      units: [{ name: 'imageGeneration', rate: 0.3, strategy: 'fixed', unit: 'image' }],
+      units: [{ name: 'imageGeneration', rate: 0.5, strategy: 'fixed', unit: 'image' }],
     },
-    releasedAt: '2026-01-16',
+    releasedAt: '2026-01-17',
     type: 'image',
   },
   {
     description:
-      'Qwen Image Edit is an image-to-image model that edits images based on input images and text prompts, enabling precise adjustments and creative transformations.',
+      'Qwen Image Editing Model supports multi-image input and multi-image output, enabling precise in-image text editing, object addition, removal, or relocation, subject action modification, image style transfer, and enhanced visual detail.',
     displayName: 'Qwen Image Edit Plus',
     enabled: true,
     id: 'qwen-image-edit-plus',
@@ -2243,9 +2245,9 @@ const qwenImageModels: AIImageModelCard[] = [
     },
     pricing: {
       currency: 'CNY',
-      units: [{ name: 'imageGeneration', rate: 0.3, strategy: 'fixed', unit: 'image' }],
+      units: [{ name: 'imageGeneration', rate: 0.2, strategy: 'fixed', unit: 'image' }],
     },
-    releasedAt: '2025-10-30',
+    releasedAt: '2025-12-23',
     type: 'image',
   },
   {
@@ -2273,7 +2275,7 @@ const qwenImageModels: AIImageModelCard[] = [
   },
   {
     description:
-      'Qwen-Image is a general image generation model supporting multiple art styles and strong complex text rendering, especially Chinese and English. It supports multi-line layouts, paragraph-level text, and fine detail for complex text-image layouts.',
+      'Qwen Image Generation Model (Max series) delivers enhanced realism and visual naturalness compared with the Plus series, effectively reducing AI-generated artifacts, and demonstrating outstanding performance in human appearance, texture details, and text rendering.',
     displayName: 'Qwen Image Max',
     enabled: true,
     id: 'qwen-image-max',
@@ -2290,14 +2292,14 @@ const qwenImageModels: AIImageModelCard[] = [
     },
     pricing: {
       currency: 'CNY',
-      units: [{ name: 'imageGeneration', rate: 0.25, strategy: 'fixed', unit: 'image' }],
+      units: [{ name: 'imageGeneration', rate: 0.5, strategy: 'fixed', unit: 'image' }],
     },
-    releasedAt: '2025-12-30',
+    releasedAt: '2025-12-31',
     type: 'image',
   },
   {
     description:
-      'Qwen-Image is a general image generation model supporting multiple art styles and strong complex text rendering, especially Chinese and English. It supports multi-line layouts, paragraph-level text, and fine detail for complex text-image layouts.',
+      'It supports a wide range of artistic styles and is particularly proficient at rendering complex text within images, enabling integrated image–text layout design.',
     displayName: 'Qwen Image Plus',
     enabled: true,
     id: 'qwen-image-plus',
@@ -2314,9 +2316,9 @@ const qwenImageModels: AIImageModelCard[] = [
     },
     pricing: {
       currency: 'CNY',
-      units: [{ name: 'imageGeneration', rate: 0.25, strategy: 'fixed', unit: 'image' }],
+      units: [{ name: 'imageGeneration', rate: 0.2, strategy: 'fixed', unit: 'image' }],
     },
-    releasedAt: '2026-01-09',
+    releasedAt: '2026-01-12',
     type: 'image',
   },
   {
@@ -2344,14 +2346,16 @@ const qwenImageModels: AIImageModelCard[] = [
     type: 'image',
   },
   {
-    description:
-      'Wanxiang 2.2 Speed is the latest model with upgrades in creativity, stability, and realism, delivering fast generation and high value.',
+    description: 'Wanxiang 2.6 Image supports image editing and mixed image–text layout output.',
     displayName: 'Wanxiang2.6 Image',
     enabled: true,
     id: 'wan2.6-image',
     organization: 'Qwen',
     parameters: {
       height: { default: 1280, max: 1280, min: 768, step: 1 },
+      imageUrl: {
+        default: '',
+      },
       prompt: {
         default: '',
       },
@@ -2360,14 +2364,14 @@ const qwenImageModels: AIImageModelCard[] = [
     },
     pricing: {
       currency: 'CNY',
-      units: [{ name: 'imageGeneration', rate: 0.14, strategy: 'fixed', unit: 'image' }],
+      units: [{ name: 'imageGeneration', rate: 0.2, strategy: 'fixed', unit: 'image' }],
     },
     releasedAt: '2025-07-28',
     type: 'image',
   },
   {
     description:
-      'Wanxiang 2.2 Speed is the latest model with upgrades in creativity, stability, and realism, delivering fast generation and high value.',
+      'Wanxiang 2.6 T2I supports flexible selection of image dimensions within total pixel area and aspect ratio constraints (same as Wanxiang 2.5).',
     displayName: 'Wanxiang2.6 T2I',
     enabled: true,
     id: 'wan2.6-t2i',
@@ -2382,14 +2386,14 @@ const qwenImageModels: AIImageModelCard[] = [
     },
     pricing: {
       currency: 'CNY',
-      units: [{ name: 'imageGeneration', rate: 0.14, strategy: 'fixed', unit: 'image' }],
+      units: [{ name: 'imageGeneration', rate: 0.2, strategy: 'fixed', unit: 'image' }],
     },
-    releasedAt: '2025-07-28',
+    releasedAt: '2025-12-16',
     type: 'image',
   },
   {
     description:
-      'Wanxiang 2.2 Speed is the latest model with upgrades in creativity, stability, and realism, delivering fast generation and high value.',
+      'Wanxiang 2.5 T2I supports flexible selection of image dimensions within total pixel area and aspect ratio constraints.',
     displayName: 'Wanxiang2.5 T2I Preview',
     enabled: true,
     id: 'wan2.5-t2i-preview',
@@ -2404,14 +2408,14 @@ const qwenImageModels: AIImageModelCard[] = [
     },
     pricing: {
       currency: 'CNY',
-      units: [{ name: 'imageGeneration', rate: 0.14, strategy: 'fixed', unit: 'image' }],
+      units: [{ name: 'imageGeneration', rate: 0.2, strategy: 'fixed', unit: 'image' }],
     },
-    releasedAt: '2025-07-28',
+    releasedAt: '2025-09-23',
     type: 'image',
   },
   {
     description:
-      'Wanxiang 2.2 Speed is the latest model with upgrades in creativity, stability, and realism, delivering fast generation and high value.',
+      'Wanxiang 2.2 Flash is the latest model with upgrades in creativity, stability, and realism, delivering fast generation and high value.',
     displayName: 'Wanxiang2.2 T2I Flash',
     enabled: true,
     id: 'wan2.2-t2i-flash',
@@ -2433,7 +2437,7 @@ const qwenImageModels: AIImageModelCard[] = [
   },
   {
     description:
-      'Wanxiang 2.2 Pro is the latest model with upgrades in creativity, stability, and realism, producing richer details.',
+      'Wanxiang 2.2 Plus is the latest model with upgrades in creativity, stability, and realism, producing richer details.',
     displayName: 'Wanxiang2.2 T2I Plus',
     enabled: true,
     id: 'wan2.2-t2i-plus',

--- a/packages/model-bank/src/aiModels/qwen.ts
+++ b/packages/model-bank/src/aiModels/qwen.ts
@@ -2183,6 +2183,74 @@ const qwenImageModels: AIImageModelCard[] = [
   {
     description:
       'Qwen Image Edit is an image-to-image model that edits images based on input images and text prompts, enabling precise adjustments and creative transformations.',
+    displayName: 'Z-Image Turbo',
+    enabled: true,
+    id: 'z-image-turbo',
+    organization: 'Qwen',
+    parameters: {
+      height: { default: 1024, max: 2048, min: 512, step: 1 },
+      prompt: {
+        default: '',
+      },
+      seed: { default: null },
+      width: { default: 1024, max: 2048, min: 512, step: 1 },
+    },
+    pricing: {
+      currency: 'CNY',
+      units: [{ name: 'imageGeneration', rate: 0.3, strategy: 'fixed', unit: 'image' }],
+    },
+    releasedAt: '2026-01-16',
+    type: 'image',
+  },
+  {
+    description:
+      'Qwen Image Edit is an image-to-image model that edits images based on input images and text prompts, enabling precise adjustments and creative transformations.',
+    displayName: 'Qwen Image Edit Max',
+    enabled: true,
+    id: 'qwen-image-edit-max',
+    organization: 'Qwen',
+    parameters: {
+      imageUrl: {
+        default: '',
+      },
+      prompt: {
+        default: '',
+      },
+      seed: { default: null },
+    },
+    pricing: {
+      currency: 'CNY',
+      units: [{ name: 'imageGeneration', rate: 0.3, strategy: 'fixed', unit: 'image' }],
+    },
+    releasedAt: '2026-01-16',
+    type: 'image',
+  },
+  {
+    description:
+      'Qwen Image Edit is an image-to-image model that edits images based on input images and text prompts, enabling precise adjustments and creative transformations.',
+    displayName: 'Qwen Image Edit Plus',
+    enabled: true,
+    id: 'qwen-image-edit-plus',
+    organization: 'Qwen',
+    parameters: {
+      imageUrl: {
+        default: '',
+      },
+      prompt: {
+        default: '',
+      },
+      seed: { default: null },
+    },
+    pricing: {
+      currency: 'CNY',
+      units: [{ name: 'imageGeneration', rate: 0.3, strategy: 'fixed', unit: 'image' }],
+    },
+    releasedAt: '2025-10-30',
+    type: 'image',
+  },
+  {
+    description:
+      'Qwen Image Edit is an image-to-image model that edits images based on input images and text prompts, enabling precise adjustments and creative transformations.',
     displayName: 'Qwen Image Edit',
     enabled: true,
     id: 'qwen-image-edit',
@@ -2201,6 +2269,54 @@ const qwenImageModels: AIImageModelCard[] = [
       units: [{ name: 'imageGeneration', rate: 0.3, strategy: 'fixed', unit: 'image' }],
     },
     releasedAt: '2025-09-18',
+    type: 'image',
+  },
+  {
+    description:
+      'Qwen-Image is a general image generation model supporting multiple art styles and strong complex text rendering, especially Chinese and English. It supports multi-line layouts, paragraph-level text, and fine detail for complex text-image layouts.',
+    displayName: 'Qwen Image Max',
+    enabled: true,
+    id: 'qwen-image-max',
+    organization: 'Qwen',
+    parameters: {
+      prompt: {
+        default: '',
+      },
+      seed: { default: null },
+      size: {
+        default: '1664x928',
+        enum: ['1664x928', '1472x1140', '1328x1328', '1140x1472', '928x1664'],
+      },
+    },
+    pricing: {
+      currency: 'CNY',
+      units: [{ name: 'imageGeneration', rate: 0.25, strategy: 'fixed', unit: 'image' }],
+    },
+    releasedAt: '2025-12-30',
+    type: 'image',
+  },
+  {
+    description:
+      'Qwen-Image is a general image generation model supporting multiple art styles and strong complex text rendering, especially Chinese and English. It supports multi-line layouts, paragraph-level text, and fine detail for complex text-image layouts.',
+    displayName: 'Qwen Image Plus',
+    enabled: true,
+    id: 'qwen-image-plus',
+    organization: 'Qwen',
+    parameters: {
+      prompt: {
+        default: '',
+      },
+      seed: { default: null },
+      size: {
+        default: '1664x928',
+        enum: ['1664x928', '1472x1140', '1328x1328', '1140x1472', '928x1664'],
+      },
+    },
+    pricing: {
+      currency: 'CNY',
+      units: [{ name: 'imageGeneration', rate: 0.25, strategy: 'fixed', unit: 'image' }],
+    },
+    releasedAt: '2026-01-09',
     type: 'image',
   },
   {
@@ -2225,6 +2341,72 @@ const qwenImageModels: AIImageModelCard[] = [
       units: [{ name: 'imageGeneration', rate: 0.25, strategy: 'fixed', unit: 'image' }],
     },
     releasedAt: '2025-08-13',
+    type: 'image',
+  },
+  {
+    description:
+      'Wanxiang 2.2 Speed is the latest model with upgrades in creativity, stability, and realism, delivering fast generation and high value.',
+    displayName: 'Wanxiang2.6 Image',
+    enabled: true,
+    id: 'wan2.6-image',
+    organization: 'Qwen',
+    parameters: {
+      height: { default: 1280, max: 1280, min: 768, step: 1 },
+      prompt: {
+        default: '',
+      },
+      seed: { default: null },
+      width: { default: 1280, max: 1280, min: 768, step: 1 },
+    },
+    pricing: {
+      currency: 'CNY',
+      units: [{ name: 'imageGeneration', rate: 0.14, strategy: 'fixed', unit: 'image' }],
+    },
+    releasedAt: '2025-07-28',
+    type: 'image',
+  },
+  {
+    description:
+      'Wanxiang 2.2 Speed is the latest model with upgrades in creativity, stability, and realism, delivering fast generation and high value.',
+    displayName: 'Wanxiang2.6 T2I',
+    enabled: true,
+    id: 'wan2.6-t2i',
+    organization: 'Qwen',
+    parameters: {
+      height: { default: 1280, max: 1440, min: 1280, step: 1 },
+      prompt: {
+        default: '',
+      },
+      seed: { default: null },
+      width: { default: 1280, max: 1440, min: 1280, step: 1 },
+    },
+    pricing: {
+      currency: 'CNY',
+      units: [{ name: 'imageGeneration', rate: 0.14, strategy: 'fixed', unit: 'image' }],
+    },
+    releasedAt: '2025-07-28',
+    type: 'image',
+  },
+  {
+    description:
+      'Wanxiang 2.2 Speed is the latest model with upgrades in creativity, stability, and realism, delivering fast generation and high value.',
+    displayName: 'Wanxiang2.5 T2I Preview',
+    enabled: true,
+    id: 'wan2.5-t2i-preview',
+    organization: 'Qwen',
+    parameters: {
+      height: { default: 1280, max: 1440, min: 1280, step: 1 },
+      prompt: {
+        default: '',
+      },
+      seed: { default: null },
+      width: { default: 1280, max: 1440, min: 1280, step: 1 },
+    },
+    pricing: {
+      currency: 'CNY',
+      units: [{ name: 'imageGeneration', rate: 0.14, strategy: 'fixed', unit: 'image' }],
+    },
+    releasedAt: '2025-07-28',
     type: 'image',
   },
   {

--- a/packages/model-runtime/src/providers/qwen/createImage.test.ts
+++ b/packages/model-runtime/src/providers/qwen/createImage.test.ts
@@ -658,23 +658,6 @@ describe('createQwenImage', () => {
       });
     });
 
-    it('should throw error when imageUrl is missing for qwen-image-edit', async () => {
-      const payload: CreateImagePayload = {
-        model: 'qwen-image-edit',
-        params: {
-          prompt: 'Edit this image',
-          // imageUrl is missing
-        },
-      };
-
-      await expect(createQwenImage(payload, mockOptions)).rejects.toEqual(
-        expect.objectContaining({
-          errorType: 'ProviderBizError',
-          provider: 'qwen',
-        }),
-      );
-    });
-
     it('should handle qwen-image-edit API errors', async () => {
       global.fetch = vi.fn().mockResolvedValueOnce({
         ok: false,
@@ -787,23 +770,6 @@ describe('createQwenImage', () => {
       expect(body.input.messages[0].content[0].image).toBe('https://example.com/first-image.jpg');
     });
 
-    it('should throw error when imageUrls is empty array', async () => {
-      const payload: CreateImagePayload = {
-        model: 'qwen-image-edit',
-        params: {
-          prompt: 'Edit this image',
-          imageUrls: [], // Empty array
-        },
-      };
-
-      await expect(createQwenImage(payload, mockOptions)).rejects.toEqual(
-        expect.objectContaining({
-          errorType: 'ProviderBizError',
-          provider: 'qwen',
-        }),
-      );
-    });
-
     it('should prioritize imageUrl over imageUrls when both are provided', async () => {
       const mockImageUrl = 'https://dashscope.oss-cn-beijing.aliyuncs.com/aigc/priority-test.jpg';
 
@@ -843,23 +809,6 @@ describe('createQwenImage', () => {
       // Should use imageUrl, not imageUrls
       expect(body.input.messages[0].content[0].image).toBe(
         'https://example.com/priority-image.jpg',
-      );
-    });
-
-    it('should throw error when neither imageUrl nor imageUrls are provided', async () => {
-      const payload: CreateImagePayload = {
-        model: 'qwen-image-edit',
-        params: {
-          prompt: 'Edit this image',
-          // Neither imageUrl nor imageUrls provided
-        },
-      };
-
-      await expect(createQwenImage(payload, mockOptions)).rejects.toEqual(
-        expect.objectContaining({
-          errorType: 'ProviderBizError',
-          provider: 'qwen',
-        }),
       );
     });
   });

--- a/packages/model-runtime/src/providers/qwen/createImage.ts
+++ b/packages/model-runtime/src/providers/qwen/createImage.ts
@@ -20,7 +20,7 @@ interface QwenImageTaskResponse {
 }
 
 // Interface for qwen-image-edit multimodal-generation response
-interface QwenImageEditResponse {
+interface QwenMultimodalGenerationResponse {
   output: {
     choices: Array<{
       message: {
@@ -34,31 +34,51 @@ interface QwenImageEditResponse {
 }
 
 /**
- * Create an image generation task with Qwen API for text-to-image models
+ * Create an image generation task with Qwen API
+ * Supports both text-to-image and image-to-image workflows
  */
-async function createImageTask(payload: CreateImagePayload, apiKey: string): Promise<string> {
+async function createQwenImageTask(
+  payload: CreateImagePayload,
+  apiKey: string,
+  endpoint: 'text2image' | 'image2image',
+): Promise<string> {
   const { model, params } = payload;
-  // I can only say that the design of Alibaba Cloud's API is really bad; each model has a different endpoint path.
-  const endpoint = `https://dashscope.aliyuncs.com/api/v1/services/aigc/text2image/image-synthesis`;
-  log('Creating image task with model: %s, endpoint: %s', model, endpoint);
+  const url = `https://dashscope.aliyuncs.com/api/v1/services/aigc/${endpoint}/image-synthesis`;
+  log('Creating %s task with model: %s, endpoint: %s', endpoint, model, url);
 
-  const response = await fetch(endpoint, {
+  const input: Record<string, any> = {
+    prompt: params.prompt,
+  };
+
+  const parameters: Record<string, any> = {
+    n: 1,
+    ...(typeof params.seed === 'number' ? { seed: params.seed } : {}),
+    ...(params.width && params.height
+      ? { size: `${params.width}*${params.height}` }
+      : params.size
+        ? { size: params.size.replaceAll('x', '*') }
+        : { size: '1024*1024' }),
+  };
+
+  if (endpoint === 'image2image') {
+    let images = params.imageUrls;
+    if (!images && params.imageUrl) {
+      images = [params.imageUrl];
+      log('Converting imageUrl to images array: using image %s', params.imageUrl);
+    }
+
+    if (!images || images.length === 0) {
+      throw new Error('imageUrls or imageUrl is required for image-to-image models');
+    }
+
+    input.images = images;
+  }
+
+  const response = await fetch(url, {
     body: JSON.stringify({
-      input: {
-        prompt: params.prompt,
-        // negativePrompt is not part of standard parameters
-        // but can be supported by extending the params type if needed
-      },
+      input,
       model,
-      parameters: {
-        n: 1,
-        ...(typeof params.seed === 'number' ? { seed: params.seed } : {}),
-        ...(params.width && params.height
-          ? { size: `${params.width}*${params.height}` }
-          : params.size
-            ? { size: params.size.replaceAll('x', '*') }
-            : { size: '1024*1024' }),
-      },
+      parameters,
     }),
     headers: {
       'Authorization': `Bearer ${apiKey}`,
@@ -76,7 +96,7 @@ async function createImageTask(payload: CreateImagePayload, apiKey: string): Pro
       // Failed to parse JSON error response
     }
     throw new Error(
-      `Failed to create image task (${response.status}): ${errorData?.message || response.statusText}`,
+      `Failed to create ${endpoint} task (${response.status}): ${errorData?.message || response.statusText}`,
     );
   }
 
@@ -87,10 +107,10 @@ async function createImageTask(payload: CreateImagePayload, apiKey: string): Pro
 }
 
 /**
- * Create image with Qwen image-edit API for image-to-image models
+ * Create image with Qwen multimodal-generation API for image-to-image models
  * This is a synchronous API that returns the result directly
  */
-async function createImageEdit(
+async function createMultimodalGeneration(
   payload: CreateImagePayload,
   apiKey: string,
 ): Promise<CreateImageResponse> {
@@ -143,7 +163,7 @@ async function createImageEdit(
     );
   }
 
-  const data: QwenImageEditResponse = await response.json();
+  const data: QwenMultimodalGenerationResponse = await response.json();
 
   if (!data.output.choices || data.output.choices.length === 0) {
     throw new Error('No image choices returned from qwen-image-edit API');
@@ -196,7 +216,10 @@ async function queryTaskStatus(taskId: string, apiKey: string): Promise<QwenImag
 
 /**
  * Create image using Qwen API
- * Supports both text-to-image (async with polling) and image-to-image (sync) workflows
+ * Supports three types:
+ * - text2image (async with polling)
+ * - image2image (async with polling)
+ * - multimodal-generation (sync for qwen-image-edit model)
  */
 export async function createQwenImage(
   payload: CreateImagePayload,
@@ -206,17 +229,17 @@ export async function createQwenImage(
   const { model } = payload;
 
   try {
-    // Check if this is qwen-image-edit model for image-to-image
+    // Check if this is qwen-image-edit model for image-to-image (synchronous)
     if (model === 'qwen-image-edit') {
       log('Using multimodal-generation API for qwen-image-edit model');
-      return await createImageEdit(payload, apiKey);
+      return await createMultimodalGeneration(payload, apiKey);
     }
 
-    // Default to text-to-image workflow for other qwen models
-    log('Using text2image API for model: %s', model);
+    const endpoint = model.includes('i2i') ? 'image2image' : 'text2image';
+    log('Using %s API for model: %s', endpoint, model);
 
     // 1. Create image generation task
-    const taskId = await createImageTask(payload, apiKey);
+    const taskId = await createQwenImageTask(payload, apiKey, endpoint);
 
     // 2. Poll task status until completion using asyncifyPolling
     const result = await asyncifyPolling<QwenImageTaskResponse, CreateImageResponse>({

--- a/packages/model-runtime/src/providers/qwen/createImage.ts
+++ b/packages/model-runtime/src/providers/qwen/createImage.ts
@@ -7,6 +7,25 @@ import { AgentRuntimeError } from '../../utils/createError';
 
 const log = createDebug('lobe-image:qwen');
 
+const text2ImageModels = new Set([
+  'wan2.5-t2i-preview',
+  'wan2.2-t2i-flash',
+  'wan2.2-t2i-plus',
+  'wanx2.1-t2i-turbo',
+  'wanx2.1-t2i-plus',
+  'wanx2.0-t2i-turbo',
+  'wanx-v1',
+  'stable-diffusion-xl',
+  'stable-diffusion-v1.5',
+  'stable-diffusion-3.5-large',
+  'stable-diffusion-3.5-large-turbo',
+  'flux-schnell',
+  'flux-dev',
+  'flux-merged',
+]);
+
+const image2ImageModels = new Set(['wan2.5-i2i-preview', 'wanx2.1-imageedit']);
+
 interface QwenImageTaskResponse {
   output: {
     error_message?: string;
@@ -217,9 +236,9 @@ async function queryTaskStatus(taskId: string, apiKey: string): Promise<QwenImag
 /**
  * Create image using Qwen API
  * Supports three types:
- * - text2image (async with polling)
- * - image2image (async with polling)
- * - multimodal-generation (sync for qwen-image-edit model)
+ * - text2image (async with polling for legacy models)
+ * - image2image (async with polling for legacy models)
+ * - multimodal-generation (sync for new models, default fallback)
  */
 export async function createQwenImage(
   payload: CreateImagePayload,
@@ -229,59 +248,103 @@ export async function createQwenImage(
   const { model } = payload;
 
   try {
-    // Check if this is qwen-image-edit model for image-to-image (synchronous)
-    if (model === 'qwen-image-edit') {
-      log('Using multimodal-generation API for qwen-image-edit model');
-      return await createMultimodalGeneration(payload, apiKey);
-    }
+    const isImage2ImageModel = image2ImageModels.has(model);
+    const isText2ImageModel = text2ImageModels.has(model);
 
-    const endpoint = model.includes('i2i') ? 'image2image' : 'text2image';
-    log('Using %s API for model: %s', endpoint, model);
+    if (isImage2ImageModel) {
+      log('Using image2image API for model: %s', model);
 
-    // 1. Create image generation task
-    const taskId = await createQwenImageTask(payload, apiKey, endpoint);
+      const taskId = await createQwenImageTask(payload, apiKey, 'image2image');
 
-    // 2. Poll task status until completion using asyncifyPolling
-    const result = await asyncifyPolling<QwenImageTaskResponse, CreateImageResponse>({
-      checkStatus: (taskStatus: QwenImageTaskResponse): TaskResult<CreateImageResponse> => {
-        log('Task %s status: %s', taskId, taskStatus.output.task_status);
+      const result = await asyncifyPolling<QwenImageTaskResponse, CreateImageResponse>({
+        checkStatus: (taskStatus: QwenImageTaskResponse): TaskResult<CreateImageResponse> => {
+          log('Task %s status: %s', taskId, taskStatus.output.task_status);
 
-        if (taskStatus.output.task_status === 'SUCCEEDED') {
-          if (!taskStatus.output.results || taskStatus.output.results.length === 0) {
+          if (taskStatus.output.task_status === 'SUCCEEDED') {
+            if (!taskStatus.output.results || taskStatus.output.results.length === 0) {
+              return {
+                error: new Error('Task succeeded but no images generated'),
+                status: 'failed',
+              };
+            }
+
+            const generatedImageUrl = taskStatus.output.results[0].url;
+            log('Image generated successfully: %s', generatedImageUrl);
+
             return {
-              error: new Error('Task succeeded but no images generated'),
+              data: { imageUrl: generatedImageUrl },
+              status: 'success',
+            };
+          }
+
+          if (taskStatus.output.task_status === 'FAILED') {
+            const errorMessage = taskStatus.output.error_message || 'Image generation task failed';
+            return {
+              error: new Error(`Qwen image generation failed: ${errorMessage}`),
               status: 'failed',
             };
           }
 
-          const generatedImageUrl = taskStatus.output.results[0].url;
-          log('Image generated successfully: %s', generatedImageUrl);
+          return { status: 'pending' };
+        },
+        logger: {
+          debug: (message: any, ...args: any[]) => log(message, ...args),
+          error: (message: any, ...args: any[]) => log(message, ...args),
+        },
+        pollingQuery: () => queryTaskStatus(taskId, apiKey),
+      });
 
-          return {
-            data: { imageUrl: generatedImageUrl },
-            status: 'success',
-          };
-        }
+      return result;
+    }
 
-        if (taskStatus.output.task_status === 'FAILED') {
-          const errorMessage = taskStatus.output.error_message || 'Image generation task failed';
-          return {
-            error: new Error(`Qwen image generation failed: ${errorMessage}`),
-            status: 'failed',
-          };
-        }
+    if (isText2ImageModel) {
+      log('Using text2image API for model: %s', model);
 
-        // Continue polling for pending/running status or other unknown statuses
-        return { status: 'pending' };
-      },
-      logger: {
-        debug: (message: any, ...args: any[]) => log(message, ...args),
-        error: (message: any, ...args: any[]) => log(message, ...args),
-      },
-      pollingQuery: () => queryTaskStatus(taskId, apiKey),
-    });
+      const taskId = await createQwenImageTask(payload, apiKey, 'text2image');
 
-    return result;
+      const result = await asyncifyPolling<QwenImageTaskResponse, CreateImageResponse>({
+        checkStatus: (taskStatus: QwenImageTaskResponse): TaskResult<CreateImageResponse> => {
+          log('Task %s status: %s', taskId, taskStatus.output.task_status);
+
+          if (taskStatus.output.task_status === 'SUCCEEDED') {
+            if (!taskStatus.output.results || taskStatus.output.results.length === 0) {
+              return {
+                error: new Error('Task succeeded but no images generated'),
+                status: 'failed',
+              };
+            }
+
+            const generatedImageUrl = taskStatus.output.results[0].url;
+            log('Image generated successfully: %s', generatedImageUrl);
+
+            return {
+              data: { imageUrl: generatedImageUrl },
+              status: 'success',
+            };
+          }
+
+          if (taskStatus.output.task_status === 'FAILED') {
+            const errorMessage = taskStatus.output.error_message || 'Image generation task failed';
+            return {
+              error: new Error(`Qwen image generation failed: ${errorMessage}`),
+              status: 'failed',
+            };
+          }
+
+          return { status: 'pending' };
+        },
+        logger: {
+          debug: (message: any, ...args: any[]) => log(message, ...args),
+          error: (message: any, ...args: any[]) => log(message, ...args),
+        },
+        pollingQuery: () => queryTaskStatus(taskId, apiKey),
+      });
+
+      return result;
+    }
+
+    log('Using multimodal-generation API for model: %s', model);
+    return await createMultimodalGeneration(payload, apiKey);
   } catch (error) {
     log('Error in createQwenImage: %O', error);
 

--- a/packages/model-runtime/src/providers/qwen/createImage.ts
+++ b/packages/model-runtime/src/providers/qwen/createImage.ts
@@ -24,7 +24,7 @@ const text2ImageModels = new Set([
   'flux-merged',
 ]);
 
-const image2ImageModels = new Set(['wan2.5-i2i-preview', 'wanx2.1-imageedit']);
+const image2ImageModels = new Set(['wan2.5-i2i-preview']);
 
 interface QwenImageTaskResponse {
   output: {
@@ -248,10 +248,7 @@ export async function createQwenImage(
   const { model } = payload;
 
   try {
-    const isImage2ImageModel = image2ImageModels.has(model);
-    const isText2ImageModel = text2ImageModels.has(model);
-
-    if (isImage2ImageModel) {
+    if (image2ImageModels.has(model)) {
       log('Using image2image API for model: %s', model);
 
       const taskId = await createQwenImageTask(payload, apiKey, 'image2image');
@@ -297,7 +294,7 @@ export async function createQwenImage(
       return result;
     }
 
-    if (isText2ImageModel) {
+    if (text2ImageModels.has(model)) {
       log('Using text2image API for model: %s', model);
 
       const taskId = await createQwenImageTask(payload, apiKey, 'text2image');

--- a/packages/model-runtime/src/providers/qwen/createImage.ts
+++ b/packages/model-runtime/src/providers/qwen/createImage.ts
@@ -38,7 +38,7 @@ interface QwenImageTaskResponse {
   request_id: string;
 }
 
-// Interface for qwen-image-edit multimodal-generation response
+// Interface for multimodal-generation response
 interface QwenMultimodalGenerationResponse {
   output: {
     choices: Array<{
@@ -126,8 +126,9 @@ async function createQwenImageTask(
 }
 
 /**
- * Create image with Qwen multimodal-generation API for image-to-image models
+ * Create image with Qwen multimodal-generation API
  * This is a synchronous API that returns the result directly
+ * Supports both text-to-image (t2i) and image-to-image (i2i) workflows
  */
 async function createMultimodalGeneration(
   payload: CreateImagePayload,
@@ -135,17 +136,16 @@ async function createMultimodalGeneration(
 ): Promise<CreateImageResponse> {
   const { model, params } = payload;
   const endpoint = `https://dashscope.aliyuncs.com/api/v1/services/aigc/multimodal-generation/generation`;
-  log('Creating image edit with model: %s, endpoint: %s', model, endpoint);
+  log('Creating image with model: %s, endpoint: %s', model, endpoint);
 
-  // Handle imageUrls to imageUrl conversion
-  let imageUrl = params.imageUrl;
-  if (!imageUrl && params.imageUrls && params.imageUrls.length > 0) {
-    imageUrl = params.imageUrls[0];
-    log('Converting imageUrls to imageUrl: using first image %s', imageUrl);
-  }
+  const content: Array<{ image: string } | { text: string }> = [{ text: params.prompt }];
 
-  if (!imageUrl) {
-    throw new Error('imageUrl or imageUrls is required for qwen-image-edit model');
+  if (params.imageUrl) {
+    content.unshift({ image: params.imageUrl });
+    log('Using imageUrl for image-to-image generation');
+  } else if (params.imageUrls && params.imageUrls.length > 0) {
+    content.unshift({ image: params.imageUrls[0] });
+    log('Using first imageUrls for image-to-image generation');
   }
 
   const response = await fetch(endpoint, {
@@ -153,7 +153,7 @@ async function createMultimodalGeneration(
       input: {
         messages: [
           {
-            content: [{ image: imageUrl }, { text: params.prompt }],
+            content,
             role: 'user',
           },
         ],
@@ -178,19 +178,19 @@ async function createMultimodalGeneration(
       // Failed to parse JSON error response
     }
     throw new Error(
-      `Failed to create image edit (${response.status}): ${errorData?.message || response.statusText}`,
+      `Failed to create image (${response.status}): ${errorData?.message || response.statusText}`,
     );
   }
 
   const data: QwenMultimodalGenerationResponse = await response.json();
 
   if (!data.output.choices || data.output.choices.length === 0) {
-    throw new Error('No image choices returned from qwen-image-edit API');
+    throw new Error('No image choices returned from API');
   }
 
   const choice = data.output.choices[0];
   if (!choice.message.content || choice.message.content.length === 0) {
-    throw new Error('No image content returned from qwen-image-edit API');
+    throw new Error('No image content returned from API');
   }
 
   const imageContent = choice.message.content.find((content) => 'image' in content);


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

将 Qwen 图像生成支持扩展到更多文生图和图生图模型，并通过相应的 Qwen API 进行路由。

新特性：
- 为新的 Qwen 图像模型添加目录条目，包括 Z-Image Turbo、Qwen Image Edit Max/Plus、Qwen Image Max/Plus、万象 2.6 Image/T2I，以及万象 2.5 T2I Preview。

增强内容：
- 基于模型标识符，在 text2image、image2image 和 multimodal-generation API 之间为 Qwen 图像请求引入显式路由。
- 通过集中化的模型集与统一的任务创建机制，拓展 Qwen 图像运行时对万象和 Stable Diffusion 模型变体的兼容性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Extend Qwen image generation support to cover additional text-to-image and image-to-image models and route them through the appropriate Qwen APIs.

New Features:
- Add catalog entries for new Qwen image models including Z-Image Turbo, Qwen Image Edit Max/Plus, Qwen Image Max/Plus, Wanxiang2.6 Image/T2I, and Wanxiang2.5 T2I Preview.

Enhancements:
- Introduce explicit routing for Qwen image requests between text2image, image2image, and multimodal-generation APIs based on model identifiers.
- Broaden compatibility of the Qwen image runtime with Wanxiang and Stable Diffusion model variants via centralized model sets and unified task creation.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

将 Qwen 图像生成支持扩展到更多文生图和图生图模型，并通过相应的 Qwen API 进行路由。

新特性：
- 为新的 Qwen 图像模型添加目录条目，包括 Z-Image Turbo、Qwen Image Edit Max/Plus、Qwen Image Max/Plus、万象 2.6 Image/T2I，以及万象 2.5 T2I Preview。

增强内容：
- 基于模型标识符，在 text2image、image2image 和 multimodal-generation API 之间为 Qwen 图像请求引入显式路由。
- 通过集中化的模型集与统一的任务创建机制，拓展 Qwen 图像运行时对万象和 Stable Diffusion 模型变体的兼容性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Extend Qwen image generation support to cover additional text-to-image and image-to-image models and route them through the appropriate Qwen APIs.

New Features:
- Add catalog entries for new Qwen image models including Z-Image Turbo, Qwen Image Edit Max/Plus, Qwen Image Max/Plus, Wanxiang2.6 Image/T2I, and Wanxiang2.5 T2I Preview.

Enhancements:
- Introduce explicit routing for Qwen image requests between text2image, image2image, and multimodal-generation APIs based on model identifiers.
- Broaden compatibility of the Qwen image runtime with Wanxiang and Stable Diffusion model variants via centralized model sets and unified task creation.

</details>

</details>