### PR TITLE
🐛 fix: remove invalid Empty.PRESENTED_IMAGE_SIMPLE property

### DIFF
--- a/src/app/[variants]/(main)/agent/cron/[cronId]/index.tsx
+++ b/src/app/[variants]/(main)/agent/cron/[cronId]/index.tsx
@@ -1,10 +1,9 @@
 'use client';
 
 import { EDITOR_DEBOUNCE_TIME } from '@lobechat/const';
-import { ActionIcon, Flexbox } from '@lobehub/ui';
+import { ActionIcon, Empty, Flexbox } from '@lobehub/ui';
 import { useDebounceFn } from 'ahooks';
 import { App, message } from 'antd';
-import { Empty } from '@lobehub/ui';
 import dayjs, { type Dayjs } from 'dayjs';
 import { Trash2 } from 'lucide-react';
 import { memo, useCallback, useEffect, useRef, useState, useSyncExternalStore } from 'react';
@@ -463,10 +462,7 @@ const CronJobDetailPage = memo(() => {
         <WideScreenContainer paddingBlock={16}>
           {isLoading && <Loading debugId="CronJobDetailPage" />}
           {!isLoading && !cronJob && !isNewJob && (
-            <Empty
-              description={t('agentCronJobs.empty.description')}
-              image={Empty.PRESENTED_IMAGE_SIMPLE}
-            />
+            <Empty description={t('agentCronJobs.empty.description')} />
           )}
           {!isLoading && (cronJob || isNewJob) && draft && (
             <Flexbox gap={24}>


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

错误修复：
- 在为定时任务（cron jobs）渲染空状态时，避免使用已弃用或无效的 `Empty.PRESENTED_IMAGE_SIMPLE` 属性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Avoid using the deprecated or invalid Empty.PRESENTED_IMAGE_SIMPLE property when rendering the empty state for cron jobs.

</details>