### PR TITLE
💄 style: add `grok-imagine-image` series support via xAI Image Generation API

### DIFF
--- a/packages/model-bank/src/aiModels/xai.ts
+++ b/packages/model-bank/src/aiModels/xai.ts
@@ -293,6 +293,84 @@ const xaiChatModels: AIChatModelCard[] = [
 const xaiImageModels: AIImageModelCard[] = [
   {
     description:
+      'Generate images from text prompts, edit existing images with natural language, or iteratively refine images through multi-turn conversations.',
+    displayName: 'Grok Imagine Image Pro',
+    enabled: true,
+    id: 'grok-imagine-image-pro',
+    parameters: {
+      aspectRatio: {
+        default: 'auto',
+        enum: [
+          'auto',
+          '1:1',
+          '3:4',
+          '4:3',
+          '9:16',
+          '16:9',
+          '2:3',
+          '3:2',
+          '9:19.5',
+          '19.5:9',
+          '9:20',
+          '20:9',
+          '1:2',
+          '2:1',
+        ],
+      },
+      imageUrls: {
+        default: [],
+      },
+      prompt: {
+        default: '',
+      },
+    },
+    pricing: {
+      units: [{ name: 'imageGeneration', rate: 0.07, strategy: 'fixed', unit: 'image' }],
+    },
+    releasedAt: '2026-01-28',
+    type: 'image',
+  },
+  {
+    description:
+      'Generate images from text prompts, edit existing images with natural language, or iteratively refine images through multi-turn conversations.',
+    displayName: 'Grok Imagine Image',
+    enabled: true,
+    id: 'grok-imagine-image',
+    parameters: {
+      aspectRatio: {
+        default: 'auto',
+        enum: [
+          'auto',
+          '1:1',
+          '3:4',
+          '4:3',
+          '9:16',
+          '16:9',
+          '2:3',
+          '3:2',
+          '9:19.5',
+          '19.5:9',
+          '9:20',
+          '20:9',
+          '1:2',
+          '2:1',
+        ],
+      },
+      imageUrls: {
+        default: [],
+      },
+      prompt: {
+        default: '',
+      },
+    },
+    pricing: {
+      units: [{ name: 'imageGeneration', rate: 0.02, strategy: 'fixed', unit: 'image' }],
+    },
+    releasedAt: '2026-01-28',
+    type: 'image',
+  },
+  {
+    description:
       'Our latest image generation model creates vivid, realistic images from prompts and excels in marketing, social media, and entertainment use cases.',
     displayName: 'Grok 2 Image 1212',
     enabled: true,
@@ -301,6 +379,9 @@ const xaiImageModels: AIImageModelCard[] = [
       prompt: {
         default: '',
       },
+    },
+    pricing: {
+      units: [{ name: 'imageGeneration', rate: 0.07, strategy: 'fixed', unit: 'image' }],
     },
     releasedAt: '2024-12-12',
     type: 'image',

--- a/packages/model-bank/src/aiModels/xai.ts
+++ b/packages/model-bank/src/aiModels/xai.ts
@@ -317,8 +317,8 @@ const xaiImageModels: AIImageModelCard[] = [
           '2:1',
         ],
       },
-      imageUrls: {
-        default: [],
+      imageUrl: {
+        default: '',
       },
       prompt: {
         default: '',
@@ -360,8 +360,8 @@ const xaiImageModels: AIImageModelCard[] = [
           '2:1',
         ],
       },
-      imageUrls: {
-        default: [],
+      imageUrl: {
+        default: '',
       },
       prompt: {
         default: '',

--- a/packages/model-bank/src/aiModels/xai.ts
+++ b/packages/model-bank/src/aiModels/xai.ts
@@ -323,6 +323,10 @@ const xaiImageModels: AIImageModelCard[] = [
       prompt: {
         default: '',
       },
+      resolution: {
+        default: '1k',
+        enum: ['1k', '2k'],
+      },
     },
     pricing: {
       units: [{ name: 'imageGeneration', rate: 0.07, strategy: 'fixed', unit: 'image' }],
@@ -361,6 +365,10 @@ const xaiImageModels: AIImageModelCard[] = [
       },
       prompt: {
         default: '',
+      },
+      resolution: {
+        default: '1k',
+        enum: ['1k', '2k'],
       },
     },
     pricing: {

--- a/packages/model-runtime/src/providers/xai/createImage.test.ts
+++ b/packages/model-runtime/src/providers/xai/createImage.test.ts
@@ -1,0 +1,537 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { CreateImageOptions } from '../../core/openaiCompatibleFactory';
+import type { CreateImagePayload } from '../../types/image';
+import { createXAIImage } from './createImage';
+
+// Mock the console.error to avoid polluting test output
+vi.spyOn(console, 'error').mockImplementation(() => {});
+
+const mockOptions: CreateImageOptions = {
+  apiKey: 'test-api-key',
+  baseURL: 'https://api.x.ai/v1',
+  provider: 'xai',
+};
+
+beforeEach(() => {
+  // Reset all mocks before each test
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('createXAIImage', () => {
+  describe('Success scenarios', () => {
+    it('should successfully generate image with basic prompt', async () => {
+      const mockImageUrl = 'https://xai-cdn.com/images/generated/test-image.jpg';
+
+      global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          data: [
+            {
+              url: mockImageUrl,
+            },
+          ],
+        }),
+      });
+
+      const payload: CreateImagePayload = {
+        model: 'grok-imagine-image',
+        params: {
+          prompt: 'A beautiful sunset over the mountains',
+        },
+      };
+
+      const result = await createXAIImage(payload, mockOptions);
+
+      expect(fetch).toHaveBeenCalledWith('https://api.x.ai/v1/images/generations', {
+        method: 'POST',
+        headers: {
+          'Authorization': 'Bearer test-api-key',
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          model: 'grok-imagine-image',
+          prompt: 'A beautiful sunset over the mountains',
+        }),
+      });
+
+      expect(result).toEqual({
+        imageUrl: mockImageUrl,
+      });
+    });
+
+    it('should handle custom aspect ratio', async () => {
+      const mockImageUrl = 'https://xai-cdn.com/images/generated/custom-ratio.jpg';
+
+      global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          data: [
+            {
+              url: mockImageUrl,
+            },
+          ],
+        }),
+      });
+
+      const payload: CreateImagePayload = {
+        model: 'grok-imagine-image',
+        params: {
+          prompt: 'Abstract digital art',
+          aspectRatio: '16:9',
+        },
+      };
+
+      const result = await createXAIImage(payload, mockOptions);
+
+      expect(fetch).toHaveBeenCalledWith(
+        'https://api.x.ai/v1/images/generations',
+        expect.objectContaining({
+          body: JSON.stringify({
+            model: 'grok-imagine-image',
+            prompt: 'Abstract digital art',
+            aspect_ratio: '16:9',
+          }),
+        }),
+      );
+
+      expect(result).toEqual({
+        imageUrl: mockImageUrl,
+      });
+    });
+
+    it('should not include aspect_ratio when value is auto', async () => {
+      const mockImageUrl = 'https://xai-cdn.com/images/generated/auto-ratio.jpg';
+
+      global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          data: [
+            {
+              url: mockImageUrl,
+            },
+          ],
+        }),
+      });
+
+      const payload: CreateImagePayload = {
+        model: 'grok-imagine-image',
+        params: {
+          prompt: 'Abstract digital art',
+          aspectRatio: 'auto',
+        },
+      };
+
+      const result = await createXAIImage(payload, mockOptions);
+
+      expect(fetch).toHaveBeenCalledWith(
+        'https://api.x.ai/v1/images/generations',
+        expect.objectContaining({
+          body: JSON.stringify({
+            model: 'grok-imagine-image',
+            prompt: 'Abstract digital art',
+          }),
+        }),
+      );
+
+      expect(result).toEqual({
+        imageUrl: mockImageUrl,
+      });
+    });
+
+    it('should handle resolution parameter', async () => {
+      const mockImageUrl = 'https://xai-cdn.com/images/generated/2k-image.jpg';
+
+      global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          data: [
+            {
+              url: mockImageUrl,
+            },
+          ],
+        }),
+      });
+
+      const payload: CreateImagePayload = {
+        model: 'grok-imagine-image',
+        params: {
+          prompt: 'An astronaut performing EVA in LEO',
+          resolution: '2k',
+        },
+      };
+
+      const result = await createXAIImage(payload, mockOptions);
+
+      expect(fetch).toHaveBeenCalledWith(
+        'https://api.x.ai/v1/images/generations',
+        expect.objectContaining({
+          body: JSON.stringify({
+            model: 'grok-imagine-image',
+            prompt: 'An astronaut performing EVA in LEO',
+            resolution: '2k',
+          }),
+        }),
+      );
+
+      expect(result).toEqual({
+        imageUrl: mockImageUrl,
+      });
+    });
+
+    it('should not include resolution when value is auto', async () => {
+      const mockImageUrl = 'https://xai-cdn.com/images/generated/auto-res.jpg';
+
+      global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          data: [
+            {
+              url: mockImageUrl,
+            },
+          ],
+        }),
+      });
+
+      const payload: CreateImagePayload = {
+        model: 'grok-imagine-image',
+        params: {
+          prompt: 'Test image',
+          resolution: 'auto',
+        },
+      };
+
+      const result = await createXAIImage(payload, mockOptions);
+
+      expect(fetch).toHaveBeenCalledWith(
+        'https://api.x.ai/v1/images/generations',
+        expect.objectContaining({
+          body: JSON.stringify({
+            model: 'grok-imagine-image',
+            prompt: 'Test image',
+          }),
+        }),
+      );
+
+      expect(result).toEqual({
+        imageUrl: mockImageUrl,
+      });
+    });
+
+    it('should handle n parameter for multiple images', async () => {
+      const mockImageUrls = [
+        'https://xai-cdn.com/images/generated/img1.jpg',
+        'https://xai-cdn.com/images/generated/img2.jpg',
+        'https://xai-cdn.com/images/generated/img3.jpg',
+        'https://xai-cdn.com/images/generated/img4.jpg',
+      ];
+
+      global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          data: mockImageUrls.map((url) => ({ url })),
+        }),
+      });
+
+      const payload: CreateImagePayload = {
+        model: 'grok-imagine-image',
+        params: {
+          prompt: 'A futuristic city skyline at night',
+          n: 4,
+        },
+      };
+
+      const result = await createXAIImage(payload, mockOptions);
+
+      expect(fetch).toHaveBeenCalledWith(
+        'https://api.x.ai/v1/images/generations',
+        expect.objectContaining({
+          body: JSON.stringify({
+            model: 'grok-imagine-image',
+            prompt: 'A futuristic city skyline at night',
+            n: 4,
+          }),
+        }),
+      );
+
+      expect(result).toEqual({
+        imageUrl: mockImageUrls[0],
+      });
+    });
+
+    it('should handle image editing mode with imageUrl', async () => {
+      const mockImageUrl = 'https://xai-cdn.com/images/generated/edited-image.jpg';
+
+      global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          data: [
+            {
+              url: mockImageUrl,
+            },
+          ],
+        }),
+      });
+
+      const payload: CreateImagePayload = {
+        model: 'grok-imagine-image',
+        params: {
+          prompt: 'Change the landmarks to be New York City landmarks',
+          imageUrls: ['https://example.com/landmarks.jpg'],
+        },
+      };
+
+      const result = await createXAIImage(payload, mockOptions);
+
+      expect(fetch).toHaveBeenCalledWith(
+        'https://api.x.ai/v1/images/edits',
+        expect.objectContaining({
+          body: JSON.stringify({
+            model: 'grok-imagine-image',
+            prompt: 'Change the landmarks to be New York City landmarks',
+            image: {
+              type: 'image_url',
+              url: 'https://example.com/landmarks.jpg',
+            },
+          }),
+        }),
+      );
+
+      expect(result).toEqual({
+        imageUrl: mockImageUrl,
+      });
+    });
+
+    it('should handle multiple generated images and return the first one', async () => {
+      const mockImageUrls = [
+        'https://xai-cdn.com/images/generated/image-1.jpg',
+        'https://xai-cdn.com/images/generated/image-2.jpg',
+      ];
+
+      global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          data: [
+            {
+              url: mockImageUrls[0],
+            },
+            {
+              url: mockImageUrls[1],
+            },
+          ],
+        }),
+      });
+
+      const payload: CreateImagePayload = {
+        model: 'grok-imagine-image',
+        params: {
+          prompt: 'Multiple images test',
+        },
+      };
+
+      const result = await createXAIImage(payload, mockOptions);
+
+      expect(result).toEqual({
+        imageUrl: mockImageUrls[0], // Should return the first image
+      });
+    });
+  });
+
+  describe('Error scenarios', () => {
+    it('should handle HTTP error responses', async () => {
+      global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: false,
+        status: 400,
+        statusText: 'Bad Request',
+        json: async () => ({
+          error: {
+            message: 'Invalid prompt format',
+          },
+        }),
+      });
+
+      const payload: CreateImagePayload = {
+        model: 'grok-imagine-image',
+        params: {
+          prompt: 'Invalid prompt',
+        },
+      };
+
+      await expect(createXAIImage(payload, mockOptions)).rejects.toEqual(
+        expect.objectContaining({
+          errorType: 'ProviderBizError',
+          provider: 'xai',
+        }),
+      );
+    });
+
+    it('should handle non-JSON error responses', async () => {
+      global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        statusText: 'Internal Server Error',
+        json: async () => {
+          throw new Error('Failed to parse JSON');
+        },
+      });
+
+      const payload: CreateImagePayload = {
+        model: 'grok-imagine-image',
+        params: {
+          prompt: 'Test prompt',
+        },
+      };
+
+      await expect(createXAIImage(payload, mockOptions)).rejects.toEqual(
+        expect.objectContaining({
+          errorType: 'ProviderBizError',
+          provider: 'xai',
+        }),
+      );
+    });
+
+    it('should handle empty data array', async () => {
+      global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          data: [],
+        }),
+      });
+
+      const payload: CreateImagePayload = {
+        model: 'grok-imagine-image',
+        params: {
+          prompt: 'Empty result test',
+        },
+      };
+
+      await expect(createXAIImage(payload, mockOptions)).rejects.toEqual(
+        expect.objectContaining({
+          errorType: 'ProviderBizError',
+          provider: 'xai',
+        }),
+      );
+    });
+
+    it('should handle missing data field', async () => {
+      global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({}),
+      });
+
+      const payload: CreateImagePayload = {
+        model: 'grok-imagine-image',
+        params: {
+          prompt: 'Missing data test',
+        },
+      };
+
+      await expect(createXAIImage(payload, mockOptions)).rejects.toEqual(
+        expect.objectContaining({
+          errorType: 'ProviderBizError',
+          provider: 'xai',
+        }),
+      );
+    });
+
+    it('should handle null/empty image URL', async () => {
+      global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          data: [
+            {
+              url: '',
+            },
+          ],
+        }),
+      });
+
+      const payload: CreateImagePayload = {
+        model: 'grok-imagine-image',
+        params: {
+          prompt: 'Empty URL test',
+        },
+      };
+
+      await expect(createXAIImage(payload, mockOptions)).rejects.toEqual(
+        expect.objectContaining({
+          errorType: 'ProviderBizError',
+          provider: 'xai',
+        }),
+      );
+    });
+
+    it('should handle network errors', async () => {
+      global.fetch = vi.fn().mockRejectedValueOnce(new Error('Network connection failed'));
+
+      const payload: CreateImagePayload = {
+        model: 'grok-imagine-image',
+        params: {
+          prompt: 'Network error test',
+        },
+      };
+
+      await expect(createXAIImage(payload, mockOptions)).rejects.toEqual(
+        expect.objectContaining({
+          errorType: 'ProviderBizError',
+          provider: 'xai',
+        }),
+      );
+    });
+
+    it('should handle unauthorized access', async () => {
+      global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+        statusText: 'Unauthorized',
+        json: async () => ({
+          error: {
+            message: 'Invalid API key',
+          },
+        }),
+      });
+
+      const payload: CreateImagePayload = {
+        model: 'grok-imagine-image',
+        params: {
+          prompt: 'Unauthorized test',
+        },
+      };
+
+      await expect(createXAIImage(payload, mockOptions)).rejects.toEqual(
+        expect.objectContaining({
+          errorType: 'ProviderBizError',
+          provider: 'xai',
+        }),
+      );
+    });
+
+    it('should handle malformed JSON response', async () => {
+      global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
+        json: async () => {
+          throw new Error('Unexpected token in JSON');
+        },
+      });
+
+      const payload: CreateImagePayload = {
+        model: 'grok-imagine-image',
+        params: {
+          prompt: 'JSON error test',
+        },
+      };
+
+      await expect(createXAIImage(payload, mockOptions)).rejects.toEqual(
+        expect.objectContaining({
+          errorType: 'ProviderBizError',
+          provider: 'xai',
+        }),
+      );
+    });
+  });
+});

--- a/packages/model-runtime/src/providers/xai/createImage.test.ts
+++ b/packages/model-runtime/src/providers/xai/createImage.test.ts
@@ -184,8 +184,8 @@ describe('createXAIImage', () => {
       });
     });
 
-    it('should not include resolution when value is auto', async () => {
-      const mockImageUrl = 'https://xai-cdn.com/images/generated/auto-res.jpg';
+    it('should not include resolution when value is 1k', async () => {
+      const mockImageUrl = 'https://xai-cdn.com/images/generated/1k-res.jpg';
 
       global.fetch = vi.fn().mockResolvedValueOnce({
         ok: true,
@@ -202,7 +202,7 @@ describe('createXAIImage', () => {
         model: 'grok-imagine-image',
         params: {
           prompt: 'Test image',
-          resolution: 'auto',
+          resolution: '1k',
         },
       };
 
@@ -220,47 +220,6 @@ describe('createXAIImage', () => {
 
       expect(result).toEqual({
         imageUrl: mockImageUrl,
-      });
-    });
-
-    it('should handle n parameter for multiple images', async () => {
-      const mockImageUrls = [
-        'https://xai-cdn.com/images/generated/img1.jpg',
-        'https://xai-cdn.com/images/generated/img2.jpg',
-        'https://xai-cdn.com/images/generated/img3.jpg',
-        'https://xai-cdn.com/images/generated/img4.jpg',
-      ];
-
-      global.fetch = vi.fn().mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          data: mockImageUrls.map((url) => ({ url })),
-        }),
-      });
-
-      const payload: CreateImagePayload = {
-        model: 'grok-imagine-image',
-        params: {
-          prompt: 'A futuristic city skyline at night',
-          n: 4,
-        },
-      };
-
-      const result = await createXAIImage(payload, mockOptions);
-
-      expect(fetch).toHaveBeenCalledWith(
-        'https://api.x.ai/v1/images/generations',
-        expect.objectContaining({
-          body: JSON.stringify({
-            model: 'grok-imagine-image',
-            prompt: 'A futuristic city skyline at night',
-            n: 4,
-          }),
-        }),
-      );
-
-      expect(result).toEqual({
-        imageUrl: mockImageUrls[0],
       });
     });
 
@@ -282,7 +241,7 @@ describe('createXAIImage', () => {
         model: 'grok-imagine-image',
         params: {
           prompt: 'Change the landmarks to be New York City landmarks',
-          imageUrls: ['https://example.com/landmarks.jpg'],
+          imageUrl: 'https://example.com/landmarks.jpg',
         },
       };
 

--- a/packages/model-runtime/src/providers/xai/createImage.ts
+++ b/packages/model-runtime/src/providers/xai/createImage.ts
@@ -23,7 +23,7 @@ export async function createXAIImage(
   const { model, params } = payload;
 
   try {
-    const isImageEdit = params.imageUrls && params.imageUrls.length > 0;
+    const isImageEdit = params.imageUrl && params.imageUrl !== '';
     const endpoint = isImageEdit ? `${baseURL}/images/edits` : `${baseURL}/images/generations`;
 
     const requestBody: any = {
@@ -35,18 +35,14 @@ export async function createXAIImage(
       requestBody.aspect_ratio = params.aspectRatio;
     }
 
-    if (params.resolution && params.resolution !== 'auto') {
+    if (params.resolution && params.resolution !== '1k') {
       requestBody.resolution = params.resolution;
     }
 
-    if (params.n && params.n > 1) {
-      requestBody.n = params.n;
-    }
-
-    if (isImageEdit && params.imageUrls && params.imageUrls.length > 0) {
+    if (isImageEdit) {
       requestBody.image = {
         type: 'image_url',
-        url: params.imageUrls[0],
+        url: params.imageUrl,
       };
     }
 

--- a/packages/model-runtime/src/providers/xai/createImage.ts
+++ b/packages/model-runtime/src/providers/xai/createImage.ts
@@ -1,0 +1,103 @@
+import createDebug from 'debug';
+
+import type { CreateImageOptions } from '../../core/openaiCompatibleFactory';
+import type { CreateImagePayload, CreateImageResponse } from '../../types/image';
+import { AgentRuntimeError } from '../../utils/createError';
+
+const log = createDebug('lobe-image:xai');
+
+interface XAIImageResponse {
+  data: Array<{
+    url: string;
+  }>;
+}
+
+/**
+ * Create image using XAI (Grok) API
+ */
+export async function createXAIImage(
+  payload: CreateImagePayload,
+  options: CreateImageOptions,
+): Promise<CreateImageResponse> {
+  const { apiKey, baseURL, provider } = options;
+  const { model, params } = payload;
+
+  try {
+    const isImageEdit = params.imageUrls && params.imageUrls.length > 0;
+    const endpoint = isImageEdit ? `${baseURL}/images/edits` : `${baseURL}/images/generations`;
+
+    const requestBody: any = {
+      model,
+      prompt: params.prompt,
+    };
+
+    if (params.aspectRatio && params.aspectRatio !== 'auto') {
+      requestBody.aspect_ratio = params.aspectRatio;
+    }
+
+    if (params.resolution && params.resolution !== 'auto') {
+      requestBody.resolution = params.resolution;
+    }
+
+    if (params.n && params.n > 1) {
+      requestBody.n = params.n;
+    }
+
+    if (isImageEdit && params.imageUrls && params.imageUrls.length > 0) {
+      requestBody.image = {
+        type: 'image_url',
+        url: params.imageUrls[0],
+      };
+    }
+
+    log('Calling XAI image API: %s with body: %O', endpoint, requestBody);
+
+    const response = await fetch(endpoint, {
+      body: JSON.stringify(requestBody),
+      headers: {
+        'Authorization': `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      method: 'POST',
+    });
+
+    if (!response.ok) {
+      let errorData;
+      try {
+        errorData = await response.json();
+      } catch {
+        // Failed to parse JSON error response
+      }
+
+      throw new Error(
+        `XAI API error (${response.status}): ${errorData?.error?.message || response.statusText}`,
+      );
+    }
+
+    const data: XAIImageResponse = await response.json();
+
+    log('Image generation response: %O', data);
+
+    if (!data.data || data.data.length === 0) {
+      throw new Error('No images generated in response');
+    }
+
+    const imageUrl = data.data[0].url;
+
+    if (!imageUrl) {
+      throw new Error('No valid image URL in response');
+    }
+
+    log('Image generated successfully: %s', imageUrl);
+
+    return { imageUrl };
+  } catch (error) {
+    log('Error in createXAIImage: %O', error);
+
+    throw AgentRuntimeError.createImage({
+      error: error as any,
+      errorType: 'ProviderBizError',
+      provider,
+    });
+  }
+}

--- a/packages/model-runtime/src/providers/xai/index.ts
+++ b/packages/model-runtime/src/providers/xai/index.ts
@@ -2,6 +2,7 @@ import { ModelProvider } from 'model-bank';
 
 import { createOpenAICompatibleRuntime } from '../../core/openaiCompatibleFactory';
 import { MODEL_LIST_CONFIGS, processModelList } from '../../utils/modelParse';
+import { createXAIImage } from './createImage';
 
 export interface XAIModelCard {
   id: string;
@@ -14,6 +15,7 @@ export const isGrokReasoningModel = (model: string) =>
 
 export const LobeXAI = createOpenAICompatibleRuntime({
   baseURL: 'https://api.x.ai/v1',
+  createImage: createXAIImage,
   chatCompletion: {
     handlePayload: (payload) => {
       const { enabledSearch, frequency_penalty, model, presence_penalty, ...rest } = payload;


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [X] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

为 xAI Grok Imagine Image 模型添加支持，并将其接入 XAI 提供商的图像生成管线。

New Features:
- 引入 Grok Imagine Image 和 Grok Imagine Image Pro 图像模型定义，支持可配置的纵横比、分辨率以及定价元数据。
- 实现一个 xAI 图像创建辅助工具（helper），用于调用 xAI 的图像生成和编辑端点，包括对纵横比、分辨率以及通过 imageUrl 进行图像编辑的支持。

Enhancements:
- 将 XAI 提供商运行时接入新的图像创建辅助工具，用于处理图像生成请求，并为现有的 `xai-image-1` 模型添加定价元数据。

Tests:
- 为 XAI 图像创建辅助工具添加全面的单元测试，覆盖成功生成、参数处理以及多种错误场景。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for xAI Grok Imagine Image models and wire them into the XAI provider image generation pipeline.

New Features:
- Introduce Grok Imagine Image and Grok Imagine Image Pro image model definitions with configurable aspect ratio, resolution, and pricing metadata.
- Implement an xAI image creation helper that calls the xAI image generation and edit endpoints, including support for aspect ratio, resolution, and image editing via imageUrl.

Enhancements:
- Wire the XAI provider runtime to use the new image creation helper for image generation requests and add pricing metadata for the existing xai-image-1 model.

Tests:
- Add comprehensive unit tests for the XAI image creation helper covering successful generation, parameter handling, and various error scenarios.

</details>