### PR TITLE
🐛 fix: Remove ffmpeg binary from outputFileTracingIncludes

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -18,11 +18,6 @@ const nextConfig = defineConfig({
         ],
       }
     : undefined,
-  // Include ffmpeg binary for video webhook processing
-  // refs: https://github.com/vercel-labs/ffmpeg-on-vercel
-  outputFileTracingIncludes: {
-    '/api/webhooks/video/*': ['./node_modules/ffmpeg-static/ffmpeg'],
-  },
   webpack: (webpackConfig, context) => {
     const { dev } = context;
     if (!dev) {


### PR DESCRIPTION
Removed ffmpeg binary inclusion for video webhook processing.

#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## 由 Sourcery 提供的摘要

构建：
- 在 Next.js 构建过程中，停止通过 `outputFileTracingIncludes` 为视频 webhook API 路由包含 `ffmpeg-static` 二进制文件。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Build:
- Stop including the ffmpeg-static binary via outputFileTracingIncludes for video webhook API routes in the Next.js build.

</details>