### PR TITLE
fix: fix embdding chunk_size limit for qwen

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -374,6 +374,17 @@ OPENAI_API_KEY=sk-xxxxxxxxx
 # Specify the Embedding model and Reranker model(unImplemented)
 # DEFAULT_FILES_CONFIG="embedding_model=openai/embedding-text-3-small,reranker_model=cohere/rerank-english-v3.0,query_mode=full_text"
 
+# Embedding batch size for processing (default: 50)
+# Note: Adjust based on provider limits:
+# - Qwen text-embedding-v3/v4: recommended 10
+# - Qwen text-embedding-v1/v2: recommended 25
+# - Most other providers: 50-100
+# EMBEDDING_BATCH_SIZE=50
+
+# Embedding concurrency for parallel processing (default: 10)
+# Higher values may increase speed but consume more API quota
+# EMBEDDING_CONCURRENCY=10
+
 # #######################################
 # ######### MCP Service Config ##########
 # #######################################

--- a/src/envs/file.ts
+++ b/src/envs/file.ts
@@ -42,8 +42,8 @@ export const getFileConfig = () => {
     server: {
       CHUNKS_AUTO_EMBEDDING: z.boolean(),
       CHUNKS_AUTO_GEN_METADATA: z.boolean(),
-      EMBEDDING_BATCH_SIZE: z.number(),
-      EMBEDDING_CONCURRENCY: z.number(),
+      EMBEDDING_BATCH_SIZE: z.number().int().positive(),
+      EMBEDDING_CONCURRENCY: z.number().int().positive(),
 
       // S3
       S3_ACCESS_KEY_ID: z.string().optional(),

--- a/src/envs/file.ts
+++ b/src/envs/file.ts
@@ -23,6 +23,8 @@ export const getFileConfig = () => {
     runtimeEnv: {
       CHUNKS_AUTO_EMBEDDING: process.env.CHUNKS_AUTO_EMBEDDING !== '0',
       CHUNKS_AUTO_GEN_METADATA: process.env.CHUNKS_AUTO_GEN_METADATA !== '0',
+      EMBEDDING_BATCH_SIZE: parseInt(process.env.EMBEDDING_BATCH_SIZE || '50'),
+      EMBEDDING_CONCURRENCY: parseInt(process.env.EMBEDDING_CONCURRENCY || '10'),
 
       NEXT_PUBLIC_S3_DOMAIN: process.env.NEXT_PUBLIC_S3_DOMAIN,
       NEXT_PUBLIC_S3_FILE_PATH: process.env.NEXT_PUBLIC_S3_FILE_PATH || DEFAULT_S3_FILE_PATH,
@@ -40,6 +42,8 @@ export const getFileConfig = () => {
     server: {
       CHUNKS_AUTO_EMBEDDING: z.boolean(),
       CHUNKS_AUTO_GEN_METADATA: z.boolean(),
+      EMBEDDING_BATCH_SIZE: z.number(),
+      EMBEDDING_CONCURRENCY: z.number(),
 
       // S3
       S3_ACCESS_KEY_ID: z.string().optional(),

--- a/src/server/routers/async/file.ts
+++ b/src/server/routers/async/file.ts
@@ -82,8 +82,8 @@ export const fileRouter = router({
 
           const startAt = Date.now();
 
-          const CHUNK_SIZE = 50;
-          const CONCURRENCY = 10;
+          const CHUNK_SIZE = fileEnv.EMBEDDING_BATCH_SIZE;
+          const CONCURRENCY = fileEnv.EMBEDDING_CONCURRENCY;
 
           const chunks = await ctx.chunkModel.getChunksTextByFileId(input.fileId);
           const requestArray = chunk(chunks, CHUNK_SIZE);


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## 由 Sourcery 提供的摘要

通过基于环境变量的批处理大小和并发设置，使嵌入分块行为可配置，用于文件处理。

新功能：
- 为嵌入操作引入可配置的运行时设置 `EMBEDDING_BATCH_SIZE` 和 `EMBEDDING_CONCURRENCY`。

改进：
- 在异步文件路由器中，使用由环境变量驱动的嵌入批处理大小和并发度，而不是硬编码的数值。

文档：
- 在示例环境配置文件中记录 `EMBEDDING_BATCH_SIZE` 和 `EMBEDDING_CONCURRENCY`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make embedding chunking behavior configurable via environment-based batch size and concurrency settings for file processing.

New Features:
- Introduce configurable EMBEDDING_BATCH_SIZE and EMBEDDING_CONCURRENCY runtime settings for embedding operations.

Enhancements:
- Use environment-driven embedding batch size and concurrency instead of hardcoded values in the async file router.

Documentation:
- Document EMBEDDING_BATCH_SIZE and EMBEDDING_CONCURRENCY in the example environment configuration file.

</details>