### PR TITLE
💄 style: add more videoGen models

### DIFF
--- a/packages/model-bank/src/aiModels/minimax.ts
+++ b/packages/model-bank/src/aiModels/minimax.ts
@@ -1,4 +1,8 @@
-import { type AIChatModelCard, type AIImageModelCard } from '../types/aiModel';
+import {
+  type AIChatModelCard,
+  type AIImageModelCard,
+  type AIVideoModelCard,
+} from '../types/aiModel';
 
 const minimaxChatModels: AIChatModelCard[] = [
   {
@@ -223,6 +227,144 @@ const minimaxImageModels: AIImageModelCard[] = [
   },
 ];
 
-export const allModels = [...minimaxChatModels, ...minimaxImageModels];
+const minimaxVideoModels: AIVideoModelCard[] = [
+  {
+    description: '',
+    displayName: 'MiniMax Hailuo 2.3 Fast',
+    enabled: true,
+    id: 'MiniMax-Hailuo-2.3-Fast',
+    parameters: {
+      duration: { default: 6, max: 10, min: 6 },
+      imageUrl: { default: null },
+      prompt: { default: '' },
+      resolution: {
+        default: '768p',
+        enum: ['768p', '1080p'],
+      },
+    },
+    releasedAt: '2026-01-28',
+    type: 'video',
+  },
+  {
+    description: '',
+    displayName: 'MiniMax Hailuo 2.3',
+    enabled: true,
+    id: 'MiniMax-Hailuo-2.3',
+    parameters: {
+      duration: { default: 6, max: 10, min: 6 },
+      imageUrl: { default: null },
+      prompt: { default: '' },
+      resolution: {
+        default: '768p',
+        enum: ['768p', '1080p'],
+      },
+    },
+    releasedAt: '2026-01-28',
+    type: 'video',
+  },
+  {
+    description: '',
+    displayName: 'MiniMax Hailuo 02',
+    enabled: true,
+    id: 'MiniMax-Hailuo-02',
+    parameters: {
+      duration: { default: 6, max: 10, min: 6 },
+      endImageUrl: { default: null, requiresImageUrl: true },
+      imageUrl: { default: null },
+      prompt: { default: '' },
+      resolution: {
+        default: '768p',
+        enum: ['512P', '768p', '1080p'],
+      },
+    },
+    releasedAt: '2026-01-28',
+    type: 'video',
+  },
+  {
+    description: '',
+    displayName: 'T2V-01-Director',
+    enabled: true,
+    id: 'T2V-01-Director',
+    parameters: {
+      duration: { default: 6, max: 6, min: 6 },
+      prompt: { default: '' },
+      resolution: {
+        default: '720p',
+        enum: ['720p'],
+      },
+    },
+    releasedAt: '2026-01-28',
+    type: 'video',
+  },
+  {
+    description: '',
+    displayName: 'I2V-01-Director',
+    enabled: true,
+    id: 'I2V-01-Director',
+    parameters: {
+      duration: { default: 6, max: 6, min: 6 },
+      imageUrl: { default: null },
+      prompt: { default: '' },
+      resolution: {
+        default: '720p',
+        enum: ['720p'],
+      },
+    },
+    releasedAt: '2026-01-28',
+    type: 'video',
+  },
+  {
+    description: '',
+    displayName: 'I2V-01-live',
+    enabled: true,
+    id: 'I2V-01-live',
+    parameters: {
+      duration: { default: 6, max: 6, min: 6 },
+      imageUrl: { default: null },
+      prompt: { default: '' },
+      resolution: {
+        default: '720p',
+        enum: ['720p'],
+      },
+    },
+    releasedAt: '2026-01-28',
+    type: 'video',
+  },
+  {
+    description: '',
+    displayName: 'I2V-01',
+    enabled: true,
+    id: 'I2V-01',
+    parameters: {
+      duration: { default: 6, max: 6, min: 6 },
+      imageUrl: { default: null },
+      prompt: { default: '' },
+      resolution: {
+        default: '720p',
+        enum: ['720p'],
+      },
+    },
+    releasedAt: '2026-01-28',
+    type: 'video',
+  },
+  {
+    description: '',
+    displayName: 'T2V-01',
+    enabled: true,
+    id: 'T2V-01',
+    parameters: {
+      duration: { default: 6, max: 6, min: 6 },
+      prompt: { default: '' },
+      resolution: {
+        default: '720p',
+        enum: ['720p'],
+      },
+    },
+    releasedAt: '2026-01-28',
+    type: 'video',
+  },
+];
+
+export const allModels = [...minimaxChatModels, ...minimaxImageModels, ...minimaxVideoModels];
 
 export default allModels;

--- a/packages/model-bank/src/aiModels/volcengine.ts
+++ b/packages/model-bank/src/aiModels/volcengine.ts
@@ -1313,8 +1313,8 @@ const volcengineVideoModels: AIVideoModelCard[] = [
     id: 'doubao-seedance-1-0-lite-i2v-250428',
     parameters: {
       aspectRatio: {
-        default: 'adaptive',
-        enum: ['adaptive', '16:9', '4:3', '1:1', '3:4', '9:16', '21:9'],
+        default: '16:9',
+        enum: ['16:9', '4:3', '1:1', '3:4', '9:16', '21:9'],
       },
       cameraFixed: { default: false },
       duration: { default: 5, max: 12, min: 2 },
@@ -1338,8 +1338,8 @@ const volcengineVideoModels: AIVideoModelCard[] = [
     id: 'doubao-seedance-1-0-lite-t2v-250428',
     parameters: {
       aspectRatio: {
-        default: 'adaptive',
-        enum: ['adaptive', '16:9', '4:3', '1:1', '3:4', '9:16', '21:9'],
+        default: '16:9',
+        enum: ['16:9', '4:3', '1:1', '3:4', '9:16', '21:9'],
       },
       cameraFixed: { default: false },
       duration: { default: 5, max: 12, min: 2 },

--- a/packages/model-bank/src/aiModels/volcengine.ts
+++ b/packages/model-bank/src/aiModels/volcengine.ts
@@ -1,4 +1,8 @@
-import { type AIChatModelCard, type AIImageModelCard } from '../types/aiModel';
+import {
+  type AIChatModelCard,
+  type AIImageModelCard,
+  type AIVideoModelCard,
+} from '../types/aiModel';
 
 // https://www.volcengine.com/docs/82379/1330310
 
@@ -1199,6 +1203,158 @@ const volcengineImageModels: AIImageModelCard[] = [
   },
 ];
 
-export const allModels = [...doubaoChatModels, ...volcengineImageModels];
+const volcengineVideoModels: AIVideoModelCard[] = [
+  {
+    description:
+      'The Doubao Large Model team has launched its new-generation professional multimodal video creation model, Seedance 2.0. It supports image, video, and audio inputs as multimodal references for video generation, and also provides capabilities such as video editing and extension. The model delivers high-precision detail reconstruction, maintains stable character consistency, and achieves highly realistic audiovisual stability. It is deeply optimized for core scenarios including commercial advertising, film and television production, and social media marketing.',
+    displayName: 'Seedance 2.0',
+    enabled: true,
+    id: 'doubao-seedance-2-0-260128',
+    parameters: {
+      aspectRatio: {
+        default: 'adaptive',
+        enum: ['adaptive', '16:9', '4:3', '1:1', '3:4', '9:16', '21:9'],
+      },
+      cameraFixed: { default: false },
+      duration: { default: 5, max: 12, min: 4 },
+      endImageUrl: { default: null, maxFileSize: 30 * 1024 * 1024, requiresImageUrl: true },
+      generateAudio: { default: true },
+      imageUrl: { default: null, maxFileSize: 30 * 1024 * 1024 },
+      prompt: { default: '' },
+      resolution: {
+        default: '720p',
+        enum: ['480p', '720p'],
+      },
+      seed: { default: null },
+    },
+    releasedAt: '2026-01-28',
+    type: 'video',
+  },
+  {
+    description:
+      'Doubao’s video generation model, Seedance 1.5 Pro, is a globally leading video generation model capable of producing videos with highly synchronized audio and visuals. It supports multi-speaker, multilingual dialogue and comprehensively covers environmental sounds, action sounds, synthetic audio, instrumental sounds, background audio, and vocals. It also supports start and end frame control, enabling cinematic-level storytelling and meeting advanced creative demands in film, animation series, e-commerce, and advertising.',
+    displayName: 'Seedance 1.5 Pro',
+    enabled: true,
+    id: 'doubao-seedance-1-5-pro-251215',
+    parameters: {
+      aspectRatio: {
+        default: 'adaptive',
+        enum: ['adaptive', '16:9', '4:3', '1:1', '3:4', '9:16', '21:9'],
+      },
+      cameraFixed: { default: false },
+      duration: { default: 5, max: 12, min: 4 },
+      endImageUrl: { default: null, maxFileSize: 30 * 1024 * 1024, requiresImageUrl: true },
+      generateAudio: { default: true },
+      imageUrl: { default: null, maxFileSize: 30 * 1024 * 1024 },
+      prompt: { default: '' },
+      resolution: {
+        default: '720p',
+        enum: ['480p', '720p', '1080p'],
+      },
+      seed: { default: null },
+    },
+    releasedAt: '2025-12-15',
+    type: 'video',
+  },
+  {
+    description:
+      'Seedance 1.0 Pro is a foundational video generation model that supports multi-shot storytelling and delivers outstanding performance across multiple dimensions. It achieves breakthroughs in semantic understanding and instruction following, enabling the generation of 1080P high-definition videos with smooth motion, rich details, diverse visual styles, and cinematic-level aesthetics.',
+    displayName: 'Seedance 1.0 Pro',
+    enabled: true,
+    id: 'doubao-seedance-1-0-pro-250528',
+    parameters: {
+      aspectRatio: {
+        default: 'adaptive',
+        enum: ['adaptive', '16:9', '4:3', '1:1', '3:4', '9:16', '21:9'],
+      },
+      cameraFixed: { default: false },
+      duration: { default: 5, max: 12, min: 2 },
+      endImageUrl: { default: null, maxFileSize: 30 * 1024 * 1024, requiresImageUrl: true },
+      imageUrl: { default: null, maxFileSize: 30 * 1024 * 1024 },
+      prompt: { default: '' },
+      resolution: {
+        default: '1080p',
+        enum: ['480p', '720p', '1080p'],
+      },
+      seed: { default: null },
+    },
+    releasedAt: '2025-05-28',
+    type: 'video',
+  },
+  {
+    description:
+      'Seedance 1.0 Pro Fast is a comprehensive model that delivers bottom-tier pricing with top-tier performance, achieving an exceptional balance among video generation quality, speed, and cost. It inherits the core strengths of Seedance 1.0 Pro, while offering faster generation speeds and more competitive pricing, providing creators with a dual optimization of efficiency and cost.',
+    displayName: 'Seedance 1.0 Pro Fast',
+    enabled: true,
+    id: 'doubao-seedance-1-0-pro-fast-251015',
+    parameters: {
+      aspectRatio: {
+        default: 'adaptive',
+        enum: ['adaptive', '16:9', '4:3', '1:1', '3:4', '9:16', '21:9'],
+      },
+      cameraFixed: { default: false },
+      duration: { default: 5, max: 12, min: 2 },
+      imageUrl: { default: null, maxFileSize: 30 * 1024 * 1024 },
+      prompt: { default: '' },
+      resolution: {
+        default: '1080p',
+        enum: ['480p', '720p', '1080p'],
+      },
+      seed: { default: null },
+    },
+    releasedAt: '2025-10-15',
+    type: 'video',
+  },
+  {
+    description:
+      'Delivers stable generation quality and strong cost-effectiveness, generating videos based on a start frame, start-and-end frames, or reference images.',
+    displayName: 'Seedance 1.0 Lite I2V',
+    enabled: true,
+    id: 'doubao-seedance-1-0-lite-i2v-250428',
+    parameters: {
+      aspectRatio: {
+        default: 'adaptive',
+        enum: ['adaptive', '16:9', '4:3', '1:1', '3:4', '9:16', '21:9'],
+      },
+      cameraFixed: { default: false },
+      duration: { default: 5, max: 12, min: 2 },
+      endImageUrl: { default: null, maxFileSize: 30 * 1024 * 1024, requiresImageUrl: true },
+      imageUrl: { default: null, maxFileSize: 30 * 1024 * 1024 },
+      prompt: { default: '' },
+      resolution: {
+        default: '720p',
+        enum: ['480p', '720p', '1080p'],
+      },
+      seed: { default: null },
+    },
+    releasedAt: '2025-04-28',
+    type: 'video',
+  },
+  {
+    description:
+      'Delivers stable generation quality and high cost-effectiveness, generating videos based on text instructions.',
+    displayName: 'Seedance 1.0 Lite T2V',
+    enabled: true,
+    id: 'doubao-seedance-1-0-lite-t2v-250428',
+    parameters: {
+      aspectRatio: {
+        default: 'adaptive',
+        enum: ['adaptive', '16:9', '4:3', '1:1', '3:4', '9:16', '21:9'],
+      },
+      cameraFixed: { default: false },
+      duration: { default: 5, max: 12, min: 2 },
+      prompt: { default: '' },
+      resolution: {
+        default: '720p',
+        enum: ['480p', '720p', '1080p'],
+      },
+      seed: { default: null },
+    },
+    releasedAt: '2025-04-28',
+    type: 'video',
+  },
+];
+
+export const allModels = [...doubaoChatModels, ...volcengineImageModels, ...volcengineVideoModels];
 
 export default allModels;

--- a/packages/model-runtime/src/providers/minimax/index.ts
+++ b/packages/model-runtime/src/providers/minimax/index.ts
@@ -3,6 +3,8 @@ import { minimax as minimaxChatModels, ModelProvider } from 'model-bank';
 import { createOpenAICompatibleRuntime } from '../../core/openaiCompatibleFactory';
 import { resolveParameters } from '../../core/parameterResolver';
 import { createMiniMaxImage } from './createImage';
+import { createMiniMaxVideo } from './video/createVideo';
+import { handleMiniMaxVideoWebhook } from './video/handleCreateVideoWebhook';
 
 export const getMinimaxMaxOutputs = (modelId: string): number | undefined => {
   const model = minimaxChatModels.find((model) => model.id === modelId);
@@ -73,8 +75,10 @@ export const LobeMinimaxAI = createOpenAICompatibleRuntime({
     },
   },
   createImage: createMiniMaxImage,
+  createVideo: createMiniMaxVideo,
   debug: {
     chatCompletion: () => process.env.DEBUG_MINIMAX_CHAT_COMPLETION === '1',
   },
+  handleCreateVideoWebhook: handleMiniMaxVideoWebhook,
   provider: ModelProvider.Minimax,
 });

--- a/packages/model-runtime/src/providers/minimax/video/createVideo.ts
+++ b/packages/model-runtime/src/providers/minimax/video/createVideo.ts
@@ -1,0 +1,82 @@
+import createDebug from 'debug';
+
+import { type CreateVideoOptions } from '../../../core/openaiCompatibleFactory';
+import { type CreateVideoPayload, type CreateVideoResponse } from '../../../types/video';
+
+const log = createDebug('lobe-video:minimax');
+
+interface MiniMaxVideoResponse {
+  base_resp: {
+    status_code: number;
+    status_msg: string;
+  };
+  data: {
+    video_url?: string;
+    task_id?: string;
+  };
+  task_id?: string;
+  video_url?: string;
+}
+
+export async function createMiniMaxVideo(
+  payload: CreateVideoPayload,
+  options: CreateVideoOptions,
+): Promise<CreateVideoResponse> {
+  const { apiKey, baseURL, provider } = options;
+  const { callbackUrl, model, params } = payload;
+  const { duration, imageUrl, endImageUrl, prompt, resolution } = params;
+
+  log('Creating video with MiniMax API - model: %s, params: %O', model, params);
+
+  const endpoint = `${baseURL}/video_generation`;
+
+  const body: Record<string, unknown> = {
+    duration,
+    model,
+    prompt,
+    resolution,
+  };
+
+  if (imageUrl) {
+    body.first_frame_image = imageUrl;
+  }
+
+  if (endImageUrl) {
+    body.last_frame_image = endImageUrl;
+  }
+
+  if (callbackUrl) {
+    body.callback_url = callbackUrl;
+  }
+
+  log('MiniMax video API request body: %s', JSON.stringify(body, null, 2));
+
+  const response = await fetch(endpoint, {
+    body: JSON.stringify(body),
+    headers: {
+      'Authorization': `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+    },
+    method: 'POST',
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    log('MiniMax video API error: %s %s', response.status, errorText);
+    throw new Error(`MiniMax video API error: ${response.status} ${errorText}`);
+  }
+
+  const data: MiniMaxVideoResponse = await response.json();
+
+  log('MiniMax video API response: %O', data);
+
+  if (data.base_resp.status_code !== 0) {
+    throw new Error(`MiniMax API error: ${data.base_resp.status_msg}`);
+  }
+
+  if (data.task_id) {
+    return { inferenceId: data.task_id };
+  }
+
+  throw new Error('Invalid response: missing task_id');
+}

--- a/packages/model-runtime/src/providers/minimax/video/handleCreateVideoWebhook.ts
+++ b/packages/model-runtime/src/providers/minimax/video/handleCreateVideoWebhook.ts
@@ -1,0 +1,95 @@
+import createDebug from 'debug';
+
+import {
+  type HandleCreateVideoWebhookPayload,
+  type HandleCreateVideoWebhookResult,
+} from '../../../types/video';
+
+const log = createDebug('lobe-video:minimax:webhook');
+
+interface MiniMaxVideoWebhookBody {
+  base_resp: {
+    status_code: number;
+    status_msg: string;
+  };
+  challenge?: string;
+  data?: {
+    video_url?: string;
+  };
+  file_id?: string;
+  status?: 'Preparing' | 'Queueing' | 'Processing' | 'Success' | 'Fail';
+  task_id?: string;
+  video_url?: string;
+}
+
+export async function handleMiniMaxVideoWebhook(
+  payload: HandleCreateVideoWebhookPayload,
+): Promise<HandleCreateVideoWebhookResult> {
+  const body = payload.body as MiniMaxVideoWebhookBody;
+
+  log('Received MiniMax video webhook: %O', body);
+
+  // Handle webhook challenge verification
+  // MiniMax sends a challenge first, we must echo it back
+  if (body.challenge) {
+    log('Webhook challenge received, this is a verification request');
+    // Return a special value that indicates this is a challenge
+    // The webhook handler will check for this and return the challenge
+    throw new Error('CHALLENGE:' + body.challenge);
+  }
+
+  // Check for API errors
+  if (body.base_resp && body.base_resp.status_code !== 0) {
+    throw new Error(`MiniMax API error: ${body.base_resp.status_msg}`);
+  }
+
+  const inferenceId = body.task_id;
+  if (!inferenceId) {
+    throw new Error('Missing task_id in webhook body');
+  }
+
+  // Skip intermediate statuses (Preparing, Queueing, Processing)
+  if (body.status === 'Preparing' || body.status === 'Queueing' || body.status === 'Processing') {
+    log('Video generation processing: %s (status: %s)', inferenceId, body.status);
+    return { status: 'pending' };
+  }
+
+  // Handle failed status
+  if (body.status === 'Fail') {
+    const errorMessage = body.base_resp?.status_msg || 'Video generation failed';
+    log('Video generation failed: %s, error: %s', inferenceId, errorMessage);
+    return { error: errorMessage, inferenceId, status: 'error' };
+  }
+
+  // Handle success status
+  if (body.status === 'Success') {
+    const videoUrl = body.video_url || body.data?.video_url;
+
+    if (!videoUrl) {
+      // If no video_url in webhook, we need to use file_id to retrieve the video
+      if (body.file_id) {
+        log(
+          'Video generation succeeded: %s, file_id: %s (video_url not in webhook)',
+          inferenceId,
+          body.file_id,
+        );
+        // Note: The calling code needs to handle this case
+        // For now, we return success and let the handler know to retrieve via file_id
+        // This is a limitation of the current implementation
+        throw new Error('NEED_FILE_ID:' + body.file_id);
+      }
+      throw new Error('Missing video_url and file_id in success webhook body');
+    }
+
+    log('Video generation succeeded: %s, videoUrl: %s', inferenceId, videoUrl);
+
+    return {
+      inferenceId,
+      status: 'success' as const,
+      videoUrl,
+    };
+  }
+
+  log('Unknown status: %s for inferenceId: %s', body.status, inferenceId);
+  return { status: 'pending' };
+}

--- a/src/app/(backend)/api/webhooks/video/[provider]/route.ts
+++ b/src/app/(backend)/api/webhooks/video/[provider]/route.ts
@@ -52,7 +52,30 @@ export const POST = async (req: Request, { params }: { params: Promise<{ provide
   try {
     // Parse webhook body using provider-specific handler
     const runtime = ModelRuntime.initializeWithProvider(provider, {});
-    const result = await runtime.handleCreateVideoWebhook({ body });
+    let result;
+    try {
+      result = await runtime.handleCreateVideoWebhook({ body });
+    } catch (error) {
+      const errorMessage = (error as Error).message;
+
+      // Handle MiniMax webhook challenge
+      if (errorMessage.startsWith('CHALLENGE:')) {
+        const challenge = errorMessage.slice('CHALLENGE:'.length);
+        log('Returning challenge response: %s', challenge);
+        return NextResponse.json({ challenge });
+      }
+
+      // Handle MiniMax need to retrieve video via file_id
+      if (errorMessage.startsWith('NEED_FILE_ID:')) {
+        const fileId = errorMessage.slice('NEED_FILE_ID:'.length);
+        log('Video succeeded but need to retrieve via file_id: %s', fileId);
+        // For now, we'll need to implement file retrieval
+        // This is a placeholder - the actual implementation would call the file retrieve API
+        throw new Error(`File retrieval not implemented for file_id: ${fileId}`);
+      }
+
+      throw error;
+    }
 
     if (!result) {
       return NextResponse.json(


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

将新的 Volcengine Seedance 视频生成模型添加到模型库中，并将其包含在统一的模型导出中。

新功能：
- 为 Volcengine 引入多个 Seedance 视频生成模型定义（Pro、Pro Fast、Lite I2V、Lite T2V），并配置相关参数和元数据。

增强内容：
- 扩展聚合模型导出功能，将新的 Volcengine 视频模型与现有的对话和图像模型一同导出。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add new Volcengine Seedance video generation models to the model bank and include them in the unified models export.

New Features:
- Introduce multiple Seedance video generation model definitions (Pro, Pro Fast, Lite I2V, Lite T2V) with associated parameters and metadata for Volcengine.

Enhancements:
- Extend the aggregated models export to include the new Volcengine video models alongside existing chat and image models.

</details>