### PR TITLE
✨ feat: add provider arg for search & crawl

### DIFF
--- a/packages/builtin-tool-web-browsing/src/ExecutionRuntime/index.ts
+++ b/packages/builtin-tool-web-browsing/src/ExecutionRuntime/index.ts
@@ -56,11 +56,15 @@ export class WebBrowsingExecutionRuntime {
   }
 
   async crawlSinglePage(args: CrawlSinglePageQuery): Promise<BuiltinServerRuntimeOutput> {
-    return this.crawlMultiPages({ urls: [args.url] });
+    return this.crawlMultiPages({
+      provider: args.provider,
+      urls: [args.url],
+    });
   }
 
   async crawlMultiPages(args: CrawlMultiPagesQuery): Promise<BuiltinServerRuntimeOutput> {
     const response = await this.searchService.crawlPages({
+      provider: args.provider,
       urls: args.urls,
     });
 

--- a/packages/builtin-tool-web-browsing/src/envHelper.ts
+++ b/packages/builtin-tool-web-browsing/src/envHelper.ts
@@ -1,0 +1,30 @@
+const parseImplEnv = (envString: string = '') => {
+  const envValue = envString.replaceAll('，', ',').trim();
+  return envValue.split(',').filter(Boolean);
+};
+
+const getSearchProviders = () => {
+  try {
+    if (typeof process !== 'undefined' && process?.env?.SEARCH_PROVIDERS) {
+      const providers = parseImplEnv(process.env.SEARCH_PROVIDERS);
+      if (providers.length > 0) {
+        return providers;
+      }
+    }
+  } catch {}
+  return ['searxng'];
+};
+
+const getCrawlerImpls = () => {
+  try {
+    if (typeof process !== 'undefined' && process?.env?.CRAWLER_IMPLS) {
+      const impls = parseImplEnv(process.env.CRAWLER_IMPLS);
+      if (impls.length > 0) {
+        return impls;
+      }
+    }
+  } catch {}
+  return ['jina'];
+};
+
+export { getCrawlerImpls, getSearchProviders, parseImplEnv };

--- a/packages/builtin-tool-web-browsing/src/manifest.ts
+++ b/packages/builtin-tool-web-browsing/src/manifest.ts
@@ -1,8 +1,12 @@
 import type { BuiltinToolManifest } from '@lobechat/types';
 import dayjs from 'dayjs';
 
+import { getCrawlerImpls, getSearchProviders } from './envHelper';
 import { systemPrompt } from './systemRole';
 import { WebBrowsingApiName } from './types';
+
+const searchProviders = getSearchProviders();
+const crawlerImpls = getCrawlerImpls();
 
 export const WebBrowsingManifest: BuiltinToolManifest = {
   api: [
@@ -12,6 +16,11 @@ export const WebBrowsingManifest: BuiltinToolManifest = {
       name: WebBrowsingApiName.search,
       parameters: {
         properties: {
+          provider: {
+            description: 'The search provider to use:',
+            enum: searchProviders,
+            type: 'string',
+          },
           query: {
             description: 'The search query',
             type: 'string',
@@ -67,6 +76,11 @@ export const WebBrowsingManifest: BuiltinToolManifest = {
       name: WebBrowsingApiName.crawlSinglePage,
       parameters: {
         properties: {
+          provider: {
+            description: 'The crawler provider to use:',
+            enum: crawlerImpls,
+            type: 'string',
+          },
           url: {
             description: 'The url need to be crawled',
             type: 'string',
@@ -82,6 +96,11 @@ export const WebBrowsingManifest: BuiltinToolManifest = {
       name: WebBrowsingApiName.crawlMultiPages,
       parameters: {
         properties: {
+          provider: {
+            description: 'The crawler provider to use:',
+            enum: crawlerImpls,
+            type: 'string',
+          },
           urls: {
             items: {
               description: 'The urls need to be crawled',

--- a/packages/builtin-tool-web-browsing/src/systemRole.ts
+++ b/packages/builtin-tool-web-browsing/src/systemRole.ts
@@ -1,25 +1,29 @@
-export const systemPrompt = (
-  date: string,
-) => `You have a Web Information tool with powerful internet access capabilities. You can search across multiple search engines and extract content from web pages to provide users with accurate, comprehensive, and up-to-date information.
+import { getCrawlerImpls, getSearchProviders } from './envHelper';
+
+export const systemPrompt = (date: string) => {
+  const searchProviders = getSearchProviders().join(', ');
+  const crawlerImpls = getCrawlerImpls().join(', ');
+
+  return `You have a Web Information tool with powerful internet access capabilities. You can search across multiple search engines and extract content from web pages to provide users with accurate, comprehensive, and up-to-date information.
 
 <core_capabilities>
-1. Search the web using multiple search engines (search)
+1. Search web using multiple search engines (search)
 2. Retrieve content from multiple webpages simultaneously (crawlMultiPages)
 3. Retrieve content from a specific webpage (crawlSinglePage)
 </core_capabilities>
 
 <workflow>
-1. Analyze the nature of the user's query (factual information, research, current events, etc.)
-2. Select the appropriate tool and search strategy based on the query type. For vague queries with no constraints, default to the 'general' category and reliable broad engines (e.g., Google).
+1. Analyze nature of user's query (factual information, research, current events, etc.)
+2. Select appropriate tool and search strategy based on query type. For vague queries with no constraints, default to 'general' category and reliable broad engines (e.g., Google).
 3. Execute searches or crawl operations to gather relevant information.
 4. Synthesize information with proper attribution of sources.
 5. Present findings in a clear, organized manner with appropriate citations.
 </workflow>
 
 <tool_selection_guidelines>
-- For general information queries: Use search with the most relevant search categories (e.g., 'general').
+- For general information queries: Use search with most relevant search categories (e.g., 'general').
 - For multi-perspective information or comparative analysis: Use 'crawlMultiPages' on several different relevant sources identified via search.
-- For detailed understanding of specific single page content: Use 'crawlSinglePage' on the most authoritative or relevant page from search results. Prefer 'crawlMultiPages' if needing to inspect multiple specific pages.
+- For detailed understanding of specific single page content: Use 'crawlSinglePage' on most authoritative or relevant page from search results. Prefer 'crawlMultiPages' if needing to inspect multiple specific pages.
 </tool_selection_guidelines>
 
 <search_categories_selection>
@@ -32,7 +36,7 @@ Choose search categories based on query type:
 </search_categories_selection>
 
 <search_engine_selection>
-Choose search engines based on the query type. For queries clearly targeting a specific non-English speaking region, strongly prefer the dominant local search engine(s) if available (e.g., Yandex for Russia).
+Choose search engines based on query type. For queries clearly targeting a specific non-English speaking region, strongly prefer to dominant local search engine(s) if available (e.g., Yandex for Russia).
 - General knowledge: google, bing, duckduckgo, brave, wikipedia
 - Academic/scientific information: google scholar, arxiv
 - Code/technical queries: google, github, npm, pypi
@@ -42,7 +46,7 @@ Choose search engines based on the query type. For queries clearly targeting a s
 </search_engine_selection>
 
 <search_time_range_selection>
-Choose time range based on the query type:
+Choose time range based on query type:
 - For no time restriction: anytime
 - For the latest updates: day
 - For recent developments: week
@@ -51,11 +55,11 @@ Choose time range based on the query type:
 </search_time_range_selection>
 
 <search_strategy_guidelines>
- - Prioritize using search categories (\`!category\`) for broader searches. Specify search engines (\`!engine\`) only when a particular engine is clearly required (e.g., \`!github\` for code) or when categories don't fit the need. Combine them if necessary (e.g., \`!science !google_scholar search term\`).
- - Use time-range filters (\`!time_range\`) to prioritize time-sensitive information.
- - Leverage cross-platform meta-search capabilities for comprehensive results, but prioritize fetching results from a few highly relevant and authoritative sources rather than exhaustively querying many engines/categories. Aim for quality over quantity.
- - Prioritize authoritative sources in search results when available.
- - Avoid using overly broad category/engine combinations unless necessary.
+- Prioritize using search categories (\`!category\`) for broader searches. Specify search engines (\`!engine\`) only when a particular engine is clearly required (e.g., \`!github\` for code) or when categories don't fit the need. Combine them if necessary (e.g., \`!science !google_scholar search term\`).
+- Use time-range filters (\`!time_range\`) to prioritize time-sensitive information.
+- Leverage cross-platform meta-search capabilities for comprehensive results, but prioritize fetching results from a few highly relevant and authoritative sources rather than exhaustively querying many engines/categories. Aim for quality over quantity.
+- Prioritize authoritative sources in search results when available.
+- Avoid using overly broad category/engine combinations unless necessary.
 </search_strategy_guidelines>
 
 <citation_requirements>
@@ -86,8 +90,14 @@ When providing information from web searches:
 3. Include proper citations using footnotes
 4. List all sources at the end of your response
 5. For time-sensitive information, note when the information was retrieved
-
 </response_format>
+
+<available_providers>
+- Available search providers: ${searchProviders}
+- Available crawler providers: ${crawlerImpls}
+
+You can optionally specify the \`provider\` parameter to use a specific search or crawler implementation. If not specified, a default provider will be used automatically based on the current configuration.
+</available_providers>
 
 <search_service_description>
 Our search service is a metasearch engine that can leverage multiple search engines including:
@@ -110,17 +120,17 @@ Our search service is a metasearch engine that can leverage multiple search engi
 - YouTube: Video sharing platform for searching various video content
 
   <search_syntax>
-  Search service has special search syntax to modify the search behavior. Use these modifiers at the beginning of your query:
+  The search service has special search syntax to modify the search behavior. Use these modifiers at the beginning of your query:
 
   1. Select Engines/Categories: Use \`!modifier\` to specify search engines or categories.
-     - Examples: \`!map paris\`, \`!images Wau Holland\`, \`!google !wikipedia berlin\`
-     - Key modifiers: \`!general\`, \`!news\`, \`!science\`, \`!it\`, \`!images\`, \`!videos\`, \`!map\`, \`!files\`, \`!social_media\`, \`!google\`, \`!bing\`, \`!github\`, etc. (Refer to selection guidelines for full lists)
+      - Examples: \`!map paris\`, \`!images Wau Holland\`, \`!google !wikipedia berlin\`
+      - Key modifiers: \`!general\`, \`!news\`, \`!science\`, \`!it\`, \`!images\`, \`!videos\`, \`!map\`, \`!files\`, \`!social_media\`, \`!google\`, \`!bing\`, \`!github\`, etc. (Refer to the selection guidelines for full lists)
 
   2. Select Language: Use \`:language_code\` to specify the search language.
-     - Example: \`:fr !wp Wau Holland\` (searches French Wikipedia)
+      - Example: \`:fr !wp Wau Holland\` (searches French Wikipedia)
 
   3. Restrict to Site: Use \`site:domain.com\` within the query string to limit results to a specific website.
-     - Example: \`site:github.com SearXNG\`
+      - Example: \`site:github.com SearXNG\`
 
   Combine modifiers as needed: \`:de !google !news bundestag\` (searches German Google News for "bundestag")
   </search_syntax>
@@ -141,10 +151,11 @@ Our search service is a metasearch engine that can leverage multiple search engi
     2. Consider trying alternative relevant search engines or categories.
     3. If the search was language-specific and failed (especially for technical, scientific, or non-regional topics), try rewriting the query or searching again using English.
     4. If needed, explain the issue to the user and suggest alternative search terms or strategies.
-- If a page cannot be crawled, explain the issue to the user and suggest alternatives (e.g., trying a different source from search results).
+- If a page cannot be crawled, explain the issue to the user and suggest alternatives (e.g., trying a different source from the search results).
 - For ambiguous queries, ask for clarification or suggest interpretations/alternative search terms before conducting extensive searches.
-- If information seems outdated, note this to the user and suggest searching for more recent sources or specifying a time range.
+- If the information seems outdated, note this to the user and suggest searching for more recent sources or specifying a time range.
 </error_handling>
 
 Current date: ${date}
 `;
+};

--- a/packages/types/src/tool/crawler.ts
+++ b/packages/types/src/tool/crawler.ts
@@ -1,10 +1,12 @@
 import type { CrawlErrorResult, CrawlSuccessResult } from '@lobechat/web-crawler';
 
 export interface CrawlSinglePageQuery {
+  provider?: string;
   url: string;
 }
 
 export interface CrawlMultiPagesQuery {
+  provider?: string;
   urls: string[];
 }
 

--- a/packages/types/src/tool/search/index.ts
+++ b/packages/types/src/tool/search/index.ts
@@ -9,6 +9,7 @@ export interface SearchParams {
 }
 
 export interface SearchQuery extends SearchParams {
+  provider?: string;
   query: string;
 }
 

--- a/src/server/services/search/index.test.ts
+++ b/src/server/services/search/index.test.ts
@@ -485,7 +485,7 @@ describe('SearchService', () => {
       searchService = new SearchService();
 
       await searchService.crawlPages({
-        impls: ['jina'],
+        provider: 'jina',
         urls: ['https://example.com'],
       });
 

--- a/src/server/services/search/index.ts
+++ b/src/server/services/search/index.ts
@@ -23,6 +23,8 @@ const parseImplEnv = (envString: string = '') => {
 export class SearchService {
   private searchImpList: SearchServiceImpl[];
 
+  private searchImpMap: Map<string, SearchServiceImpl>;
+
   private get crawlerImpls() {
     return parseImplEnv(toolsEnv.CRAWLER_IMPLS);
   }
@@ -35,22 +37,35 @@ export class SearchService {
     return toolsEnv.CRAWLER_RETRY ?? DEFAULT_CRAWLER_RETRY;
   }
 
+  private get searchImpls() {
+    return parseImplEnv(toolsEnv.SEARCH_PROVIDERS) as SearchImplType[];
+  }
+
   constructor() {
     const impls = this.searchImpls;
     this.searchImpList =
       impls.length > 0
         ? impls.map((impl) => createSearchServiceImpl(impl))
         : [createSearchServiceImpl()];
+
+    this.searchImpMap = new Map();
+    impls.forEach((impl, index) => {
+      if (index < this.searchImpList.length) {
+        this.searchImpMap.set(impl.toLowerCase(), this.searchImpList[index]);
+      }
+    });
   }
 
-  async crawlPages(input: { impls?: CrawlImplType[]; urls: string[] }) {
+  async crawlPages(input: { provider?: string; urls: string[] }) {
     const { Crawler } = await import('@lobechat/web-crawler');
     const crawler = new Crawler({ impls: this.crawlerImpls });
+
+    const implsToUse = input.provider ? ([input.provider] as CrawlImplType[]) : undefined;
 
     const results = await pMap(
       input.urls,
       async (url) => {
-        return await this.crawlWithRetry(crawler, url, input.impls);
+        return await this.crawlWithRetry(crawler, url, implsToUse);
       },
       { concurrency: this.crawlConcurrency },
     );
@@ -103,10 +118,6 @@ export class SearchService {
     return !('contentType' in result.data);
   }
 
-  private get searchImpls() {
-    return parseImplEnv(toolsEnv.SEARCH_PROVIDERS) as SearchImplType[];
-  }
-
   /**
    * Query for search results using the specified impl
    */
@@ -132,8 +143,25 @@ export class SearchService {
     return this.queryWithImpl(this.searchImpList[0], query, params);
   }
 
-  async webSearch({ query, searchCategories, searchEngines, searchTimeRange }: SearchQuery) {
-    for (const impl of this.searchImpList) {
+  async webSearch({
+    query,
+    searchCategories,
+    searchEngines,
+    searchTimeRange,
+    provider,
+  }: SearchQuery) {
+    let implsToTry = this.searchImpList;
+
+    if (provider) {
+      const providerImpl = this.searchImpMap.get(provider.toLowerCase());
+      if (!providerImpl) {
+        console.warn(`[SearchService] Provider "${provider}" not found, using default providers`);
+      } else {
+        implsToTry = [providerImpl];
+      }
+    }
+
+    for (const impl of implsToTry) {
       let data = await this.queryWithImpl(impl, query, {
         searchCategories,
         searchEngines,


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

为网页搜索和爬取工具添加可配置的提供商选择功能，并在网页浏览系统提示词和清单中暴露可用的提供商。

新功能：
- 允许在网页搜索请求中指定搜索提供商，将查询路由到所选实现。
- 允许通过工具参数和服务 API 为单页和多页爬取操作指定爬虫提供商。
- 在网页浏览工具清单中暴露可用的搜索和爬虫提供商，使其在工具参数中作为类型化枚举出现，并在模型的系统提示词中显示。

增强：
- 优化网页浏览系统提示词的措辞，并添加关于可选使用搜索和爬取 `provider` 参数的指导。
- 创建一个共享的环境助手，从环境变量中派生搜索提供商和爬虫实现，并提供合理的默认值。
- 在搜索服务中按名称缓存搜索实现，以支持直接按提供商查找。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add configurable provider selection for web search and crawling tools and expose available providers in the web browsing system prompt and manifest.

New Features:
- Allow specifying a search provider in web search requests to route queries to a chosen implementation.
- Allow specifying a crawler provider for single-page and multi-page crawl operations via tool parameters and service API.
- Expose available search and crawler providers in the web browsing tool manifest so they appear as typed enums in tool parameters and in the system prompt for the model.

Enhancements:
- Refine the web browsing system prompt wording and add guidance about optionally using the provider parameter for search and crawl.
- Create a shared environment helper to derive search providers and crawler implementations from environment variables with sensible defaults.
- Cache search implementations by name in the search service to support direct provider lookup.

</details>