### PR TITLE
♻️ refactor: refactor web search tool

### DIFF
--- a/packages/builtin-tool-web-browsing/src/ExecutionRuntime/index.ts
+++ b/packages/builtin-tool-web-browsing/src/ExecutionRuntime/index.ts
@@ -56,12 +56,13 @@ export class WebBrowsingExecutionRuntime {
   }
 
   async crawlSinglePage(args: CrawlSinglePageQuery): Promise<BuiltinServerRuntimeOutput> {
-    return this.crawlMultiPages({ urls: [args.url] });
+    return this.crawlMultiPages({ urls: [args.url], provider: args.provider });
   }
 
   async crawlMultiPages(args: CrawlMultiPagesQuery): Promise<BuiltinServerRuntimeOutput> {
     const response = await this.searchService.crawlPages({
       urls: args.urls,
+      provider: args.provider,
     });
 
     const { results } = response;

--- a/packages/builtin-tool-web-browsing/src/helper.ts
+++ b/packages/builtin-tool-web-browsing/src/helper.ts
@@ -1,0 +1,28 @@
+import { toolsEnv } from '@/envs/tools';
+import { SearchImplType } from '@/server/services/search/impls';
+
+/**
+ * Parse impl env string (handle full-width commas and extra whitespace)
+ */
+const parseImplEnv = (envString: string = '') => {
+  const envValue = envString.replaceAll('，', ',').trim();
+  return envValue.split(',').filter(Boolean);
+};
+
+/**
+ * Parse SEARCH_PROVIDERS env and get available providers
+ */
+export const getAvailableSearchProviders = (): string[] => {
+  const envString = toolsEnv.SEARCH_PROVIDERS;
+  const providers = parseImplEnv(envString || '') as SearchImplType[];
+  return providers.length > 0 ? providers : [SearchImplType.SearXNG];
+};
+
+/**
+ * Parse CRAWLER_IMPLS env and get available providers
+ */
+export const getAvailableCrawlProviders = (): string[] => {
+  const envString = toolsEnv.CRAWLER_IMPLS;
+  const providers = parseImplEnv(envString || '');
+  return providers.length > 0 ? providers : ['browserless'];
+};

--- a/packages/builtin-tool-web-browsing/src/manifest.ts
+++ b/packages/builtin-tool-web-browsing/src/manifest.ts
@@ -59,19 +59,7 @@ export const WebBrowsingManifest: BuiltinToolManifest = {
           },
           provider: {
             description: 'The search provider to use.',
-            enum: [
-              'anspire',
-              'bocha',
-              'brave',
-              'exa',
-              'firecrawl',
-              'google',
-              'jina',
-              'kagi',
-              'search1api',
-              'searxng',
-              'tavily',
-            ],
+            enum: getAvailableSearchProviders,
             type: 'string',
           },
         },
@@ -91,7 +79,7 @@ export const WebBrowsingManifest: BuiltinToolManifest = {
           },
           provider: {
             description: 'The crawler provider to use.',
-            enum: ['naive', 'jina', 'browserless', 'search1api', 'exa', 'firecrawl', 'tavily'],
+            enum: getAvailableCrawlProviders,
             type: 'string',
           },
         },
@@ -114,7 +102,7 @@ export const WebBrowsingManifest: BuiltinToolManifest = {
           },
           provider: {
             description: 'The crawler provider to use.',
-            enum: ['naive', 'jina', 'browserless', 'search1api', 'exa', 'firecrawl', 'tavily'],
+            enum: getAvailableCrawlProviders,
             type: 'string',
           },
         },

--- a/packages/builtin-tool-web-browsing/src/manifest.ts
+++ b/packages/builtin-tool-web-browsing/src/manifest.ts
@@ -59,7 +59,7 @@ export const WebBrowsingManifest: BuiltinToolManifest = {
           },
           provider: {
             description: 'The search provider to use.',
-            enum: getAvailableSearchProviders,
+            enum: getAvailableSearchProviders(),
             type: 'string',
           },
         },
@@ -79,7 +79,7 @@ export const WebBrowsingManifest: BuiltinToolManifest = {
           },
           provider: {
             description: 'The crawler provider to use.',
-            enum: getAvailableCrawlProviders,
+            enum: getAvailableCrawlProviders(),
             type: 'string',
           },
         },
@@ -102,7 +102,7 @@ export const WebBrowsingManifest: BuiltinToolManifest = {
           },
           provider: {
             description: 'The crawler provider to use.',
-            enum: getAvailableCrawlProviders,
+            enum: getAvailableCrawlProviders(),
             type: 'string',
           },
         },
@@ -122,8 +122,8 @@ export const WebBrowsingManifest: BuiltinToolManifest = {
   },
   systemRole: systemPrompt(
     dayjs(new Date()).format('YYYY-MM-DD'),
-    getAvailableSearchProviders,
-    getAvailableCrawlProviders,
+    getAvailableSearchProviders(),
+    getAvailableCrawlProviders(),
   ),
   type: 'builtin',
 };

--- a/packages/builtin-tool-web-browsing/src/manifest.ts
+++ b/packages/builtin-tool-web-browsing/src/manifest.ts
@@ -56,6 +56,23 @@ export const WebBrowsingManifest: BuiltinToolManifest = {
             enum: ['anytime', 'day', 'week', 'month', 'year'],
             type: 'string',
           },
+          provider: {
+            description: 'The search provider to use.',
+            enum: [
+              'anspire',
+              'bocha',
+              'brave',
+              'exa',
+              'firecrawl',
+              'google',
+              'jina',
+              'kagi',
+              'search1api',
+              'searxng',
+              'tavily',
+            ],
+            type: 'string',
+          },
         },
         required: ['query'],
         type: 'object',
@@ -69,6 +86,11 @@ export const WebBrowsingManifest: BuiltinToolManifest = {
         properties: {
           url: {
             description: 'The url need to be crawled',
+            type: 'string',
+          },
+          provider: {
+            description: 'The crawler provider to use.',
+            enum: ['naive', 'jina', 'browserless', 'search1api', 'exa', 'firecrawl', 'tavily'],
             type: 'string',
           },
         },
@@ -88,6 +110,11 @@ export const WebBrowsingManifest: BuiltinToolManifest = {
               type: 'string',
             },
             type: 'array',
+          },
+          provider: {
+            description: 'The crawler provider to use.',
+            enum: ['naive', 'jina', 'browserless', 'search1api', 'exa', 'firecrawl', 'tavily'],
+            type: 'string',
           },
         },
         required: ['urls'],

--- a/packages/builtin-tool-web-browsing/src/manifest.ts
+++ b/packages/builtin-tool-web-browsing/src/manifest.ts
@@ -1,6 +1,7 @@
 import type { BuiltinToolManifest } from '@lobechat/types';
 import dayjs from 'dayjs';
 
+import { getAvailableCrawlProviders, getAvailableSearchProviders } from './helper';
 import { systemPrompt } from './systemRole';
 import { WebBrowsingApiName } from './types';
 
@@ -131,6 +132,10 @@ export const WebBrowsingManifest: BuiltinToolManifest = {
       'Search the web for current information and crawl web pages to extract content. Supports multiple search engines, categories, and time ranges for comprehensive research.',
     title: 'Web Browsing',
   },
-  systemRole: systemPrompt(dayjs(new Date()).format('YYYY-MM-DD')),
+  systemRole: systemPrompt(
+    dayjs(new Date()).format('YYYY-MM-DD'),
+    getAvailableSearchProviders,
+    getAvailableCrawlProviders,
+  ),
   type: 'builtin',
 };

--- a/packages/builtin-tool-web-browsing/src/systemRole.ts
+++ b/packages/builtin-tool-web-browsing/src/systemRole.ts
@@ -1,5 +1,7 @@
 export const systemPrompt = (
   date: string,
+  searchProviders: string[],
+  crawlProviders: string[],
 ) => `You have a Web Information tool with powerful internet access capabilities. You can search across multiple search engines and extract content from web pages to provide users with accurate, comprehensive, and up-to-date information.
 
 <core_capabilities>
@@ -134,6 +136,11 @@ Our search service is a metasearch engine that can leverage multiple search engi
 - Verify information across multiple sources when possible
 - Consider the recency of information, especially for time-sensitive topics
 </crawling_best_practices>
+
+<available_providers>
+- Search providers: ${searchProviders.join(', ')}
+- Crawl providers: ${crawlProviders.join(', ')}
+</available_providers>
 
 <error_handling>
 - If a search returns poor or no results:

--- a/packages/types/src/tool/crawler.ts
+++ b/packages/types/src/tool/crawler.ts
@@ -1,10 +1,27 @@
 import type { CrawlErrorResult, CrawlSuccessResult } from '@lobechat/web-crawler';
 
+export enum CrawlProviderType {
+  Browserless = 'browserless',
+  Exa = 'exa',
+  Firecrawl = 'firecrawl',
+  Jina = 'jina',
+  Naive = 'naive',
+  Search1API = 'search1api',
+  Tavily = 'tavily',
+}
+
 export interface CrawlSinglePageQuery {
+  provider?: CrawlProviderType;
   url: string;
 }
 
 export interface CrawlMultiPagesQuery {
+  provider?: CrawlProviderType;
+  urls: string[];
+}
+
+export interface CrawlMultiPagesQuery {
+  provider?: CrawlProviderType;
   urls: string[];
 }
 

--- a/packages/types/src/tool/search/index.ts
+++ b/packages/types/src/tool/search/index.ts
@@ -9,6 +9,18 @@ export interface SearchParams {
 }
 
 export interface SearchQuery extends SearchParams {
+  provider?:
+    | 'anspire'
+    | 'bocha'
+    | 'brave'
+    | 'exa'
+    | 'firecrawl'
+    | 'google'
+    | 'jina'
+    | 'kagi'
+    | 'search1api'
+    | 'searxng'
+    | 'tavily';
   query: string;
 }
 

--- a/packages/web-crawler/src/__tests__/crawler.test.ts
+++ b/packages/web-crawler/src/__tests__/crawler.test.ts
@@ -39,21 +39,21 @@ describe('Crawler', () => {
     };
 
     const { crawlImpls } = await import('../crawImpl');
-    vi.mocked(crawlImpls.naive).mockResolvedValue(mockResult);
+    vi.mocked(crawlImpls.browserless).mockResolvedValue(mockResult);
 
     const result = await crawler.crawl({
       url: 'https://example.com',
     });
 
     expect(result).toEqual({
-      crawler: 'naive',
+      crawler: 'browserless',
       data: mockResult,
       originalUrl: 'https://example.com',
       transformedUrl: undefined,
     });
   });
 
-  it('should use user provided impls', async () => {
+  it('should use configured impl', async () => {
     const mockResult = {
       content: 'test content'.padEnd(101, ' '), // Ensure content length > 100
       contentType: 'text' as const,
@@ -63,8 +63,8 @@ describe('Crawler', () => {
     const { crawlImpls } = await import('../crawImpl');
     vi.mocked(crawlImpls.jina).mockResolvedValue(mockResult);
 
-    const result = await crawler.crawl({
-      impls: ['jina'],
+    const jinaCrawler = new Crawler({ impl: 'jina' });
+    const result = await jinaCrawler.crawl({
       url: 'https://example.com',
     });
 
@@ -81,8 +81,6 @@ describe('Crawler', () => {
     mockError.name = 'CrawlError';
 
     const { crawlImpls } = await import('../crawImpl');
-    vi.mocked(crawlImpls.naive).mockRejectedValue(mockError);
-    vi.mocked(crawlImpls.jina).mockRejectedValue(mockError);
     vi.mocked(crawlImpls.browserless).mockRejectedValue(mockError);
 
     const result = await crawler.crawl({
@@ -92,7 +90,7 @@ describe('Crawler', () => {
     expect(result).toEqual({
       crawler: 'browserless',
       data: {
-        content: 'Fail to crawl the page. Error type: CrawlError, error message: Crawl failed',
+        content: 'Fail to crawl page. Error type: CrawlError, error message: Crawl failed',
         errorMessage: 'Crawl failed',
         errorType: 'CrawlError',
       },
@@ -109,7 +107,7 @@ describe('Crawler', () => {
     };
 
     const { crawlImpls } = await import('../crawImpl');
-    vi.mocked(crawlImpls.naive).mockResolvedValue(mockResult);
+    vi.mocked(crawlImpls.browserless).mockResolvedValue(mockResult);
 
     const { applyUrlRules } = await import('../utils/appUrlRules');
     vi.mocked(applyUrlRules).mockReturnValue({
@@ -122,7 +120,7 @@ describe('Crawler', () => {
     });
 
     expect(result).toEqual({
-      crawler: 'naive',
+      crawler: 'browserless',
       data: mockResult,
       originalUrl: 'https://example.com',
       transformedUrl: 'https://transformed.example.com',
@@ -137,7 +135,7 @@ describe('Crawler', () => {
     };
 
     const { crawlImpls } = await import('../crawImpl');
-    const mockCrawlImpl = vi.mocked(crawlImpls.naive).mockResolvedValue(mockResult);
+    const mockCrawlImpl = vi.mocked(crawlImpls.browserless).mockResolvedValue(mockResult);
 
     const { applyUrlRules } = await import('../utils/appUrlRules');
     vi.mocked(applyUrlRules).mockReturnValue({
@@ -195,8 +193,6 @@ describe('Crawler', () => {
     };
 
     const { crawlImpls } = await import('../crawImpl');
-    vi.mocked(crawlImpls.naive).mockResolvedValue(mockResult);
-    vi.mocked(crawlImpls.jina).mockResolvedValue(mockResult);
     vi.mocked(crawlImpls.browserless).mockResolvedValue(mockResult);
 
     const result = await crawler.crawl({
@@ -207,7 +203,7 @@ describe('Crawler', () => {
       crawler: 'browserless',
       data: {
         content:
-          'Fail to crawl the page. Error type: EmptyCrawlResultError, error message: browserless returned empty or short content',
+          'Fail to crawl page. Error type: EmptyCrawlResultError, error message: browserless returned empty or short content',
         errorMessage: 'browserless returned empty or short content',
         errorType: 'EmptyCrawlResultError',
       },

--- a/packages/web-crawler/src/crawler.ts
+++ b/packages/web-crawler/src/crawler.ts
@@ -1,22 +1,23 @@
+import { CrawlProviderType } from '@lobechat/types';
+
 import type { CrawlImplType } from './crawImpl';
 import { crawlImpls } from './crawImpl';
 import type { CrawlUniformResult, CrawlUrlRule } from './type';
 import { crawUrlRules } from './urlRules';
 import { applyUrlRules } from './utils/appUrlRules';
 
-const defaultImpls = ['jina', 'naive', 'search1api', 'browserless'] as CrawlImplType[];
-
 interface CrawlOptions {
-  impls?: string[];
+  impl?: string;
 }
 
 export class Crawler {
-  impls: CrawlImplType[];
+  impl: CrawlImplType;
 
   constructor(options: CrawlOptions = {}) {
-    this.impls = !!options.impls?.length
-      ? (options.impls.filter((impl) => Object.keys(crawlImpls).includes(impl)) as CrawlImplType[])
-      : defaultImpls;
+    this.impl =
+      options.impl && Object.keys(crawlImpls).includes(options.impl)
+        ? (options.impl as CrawlImplType)
+        : CrawlProviderType.Browserless;
   }
 
   /**
@@ -25,11 +26,9 @@ export class Crawler {
    */
   async crawl({
     url,
-    impls: userImpls,
     filterOptions: userFilterOptions,
   }: {
     filterOptions?: CrawlUrlRule['filterOptions'];
-    impls?: CrawlImplType[];
     url: string;
   }): Promise<CrawlUniformResult> {
     // Apply URL rules
@@ -39,57 +38,55 @@ export class Crawler {
       impls: ruleImpls,
     } = applyUrlRules(url, crawUrlRules);
 
+    // Use rule impls if available, otherwise use configured impl
+    const impl = (ruleImpls?.[0] ?? this.impl) as CrawlImplType;
+
     // Merge user-provided filter options and rule filter options, user options take priority
     const mergedFilterOptions = {
       ...ruleFilterOptions,
       ...userFilterOptions,
     };
 
-    let finalCrawler: string | undefined;
-    let finalError: Error | undefined;
+    try {
+      const res = await crawlImpls[impl](transformedUrl, { filterOptions: mergedFilterOptions });
 
-    const systemImpls = (ruleImpls ?? this.impls) as CrawlImplType[];
-
-    const finalImpls = userImpls
-      ? (userImpls.filter((impl) => Object.keys(crawlImpls).includes(impl)) as CrawlImplType[])
-      : systemImpls;
-
-    // Try each implementation in the built-in order
-    for (const impl of finalImpls) {
-      try {
-        const res = await crawlImpls[impl](transformedUrl, { filterOptions: mergedFilterOptions });
-
-        if (res && res.content && res.content.length > 100) {
-          return {
-            crawler: impl,
-            data: res,
-            originalUrl: url,
-            transformedUrl: transformedUrl !== url ? transformedUrl : undefined,
-          };
-        }
-
-        finalError = new Error(`${impl} returned empty or short content`);
-        finalError.name = 'EmptyCrawlResultError';
-        finalCrawler = impl;
-      } catch (error) {
-        console.error(error);
-        finalError = error as Error;
-        finalCrawler = impl;
+      if (res && res.content && res.content.length > 100) {
+        return {
+          crawler: impl,
+          data: res,
+          originalUrl: url,
+          transformedUrl: transformedUrl !== url ? transformedUrl : undefined,
+        };
       }
+
+      const error = new Error(`${impl} returned empty or short content`);
+      error.name = 'EmptyCrawlResultError';
+
+      return {
+        crawler: impl,
+        data: {
+          content: `Fail to crawl page. Error type: ${error.name}, error message: ${error.message}`,
+          errorMessage: error.message,
+          errorType: error.name,
+        },
+        originalUrl: url,
+        transformedUrl: transformedUrl !== url ? transformedUrl : undefined,
+      };
+    } catch (error) {
+      console.error(error);
+      const errorType = (error as Error).name || 'UnknownError';
+      const errorMessage = (error as Error).message;
+
+      return {
+        crawler: impl,
+        data: {
+          content: `Fail to crawl page. Error type: ${errorType}, error message: ${errorMessage}`,
+          errorMessage,
+          errorType,
+        },
+        originalUrl: url,
+        transformedUrl: transformedUrl !== url ? transformedUrl : undefined,
+      };
     }
-
-    const errorType = finalError?.name || 'UnknownError';
-    const errorMessage = finalError?.message;
-
-    return {
-      crawler: finalCrawler || finalImpls.at(-1) || 'unknown',
-      data: {
-        content: `Fail to crawl the page. Error type: ${errorType}, error message: ${errorMessage}`,
-        errorMessage,
-        errorType,
-      },
-      originalUrl: url,
-      transformedUrl: transformedUrl !== url ? transformedUrl : undefined,
-    };
   }
 }

--- a/src/server/services/search/index.test.ts
+++ b/src/server/services/search/index.test.ts
@@ -143,7 +143,7 @@ describe('SearchService', () => {
       expect(result).toBe(mockResponse);
     });
 
-    it('should retry without searchEngines when no results found', async () => {
+    it.skip('should retry without searchEngines when no results found', async () => {
       const emptyResponse = {
         costTime: 100,
         query: 'test',
@@ -192,7 +192,7 @@ describe('SearchService', () => {
       expect(result).toBe(successResponse);
     });
 
-    it('should retry without any params when still no results found', async () => {
+    it.skip('should retry without any params when still no results found', async () => {
       const emptyResponse = {
         costTime: 100,
         query: 'test',
@@ -233,7 +233,7 @@ describe('SearchService', () => {
       expect(result).toBe(successResponse);
     });
 
-    it('should skip second retry if searchEngines not provided', async () => {
+    it.skip('should skip second retry if searchEngines not provided', async () => {
       const emptyResponse = {
         costTime: 100,
         query: 'test',
@@ -276,7 +276,7 @@ describe('SearchService', () => {
       expect(result).toBe(successResponse);
     });
 
-    it('should return empty results after all retries fail', async () => {
+    it.skip('should return empty results after all retries fail', async () => {
       const emptyResponse = {
         costTime: 100,
         query: 'test',
@@ -320,7 +320,7 @@ describe('SearchService', () => {
       ],
     };
 
-    it('should fall back to second provider when first returns no results', async () => {
+    it.skip('should fall back to second provider when first returns no results', async () => {
       const mockImpl1 = { query: vi.fn().mockResolvedValue(emptyResponse) };
       const mockImpl2 = { query: vi.fn().mockResolvedValue(successResponse) };
 
@@ -340,7 +340,7 @@ describe('SearchService', () => {
       expect(result).toBe(successResponse);
     });
 
-    it('should try all providers in order and return empty when all fail', async () => {
+    it.skip('should try all providers in order and return empty when all fail', async () => {
       const mockImpl1 = { query: vi.fn().mockResolvedValue(emptyResponse) };
       const mockImpl2 = { query: vi.fn().mockResolvedValue(emptyResponse) };
       const mockImpl3 = { query: vi.fn().mockResolvedValue(emptyResponse) };
@@ -379,7 +379,7 @@ describe('SearchService', () => {
       expect(result).toBe(successResponse);
     });
 
-    it('should exhaust all retries on first provider before falling back', async () => {
+    it.skip('should exhaust all retries on first provider before falling back', async () => {
       const mockImpl1 = { query: vi.fn().mockResolvedValue(emptyResponse) };
       const mockImpl2 = { query: vi.fn().mockResolvedValue(successResponse) };
 
@@ -401,7 +401,7 @@ describe('SearchService', () => {
       expect(result).toBe(successResponse);
     });
 
-    it('should handle provider errors gracefully and continue to next', async () => {
+    it.skip('should handle provider errors gracefully and continue to next', async () => {
       const errorResponse = {
         costTime: 0,
         errorDetail: 'Service unavailable',
@@ -445,14 +445,14 @@ describe('SearchService', () => {
       const urls = ['https://example1.com', 'https://example2.com', 'https://example3.com'];
       const result = await searchService.crawlPages({ urls });
 
-      expect(Crawler).toHaveBeenCalledWith({ impls: [] });
+      expect(Crawler).toHaveBeenCalledWith({ impl: 'naive' });
       expect(mockCrawler.crawl).toHaveBeenCalledTimes(3);
       expect(result.results).toHaveLength(3);
       expect(result.results[0]).toBe(mockCrawlResult);
     });
 
     it('should use crawler implementations from env', async () => {
-      vi.mocked(toolsEnv).CRAWLER_IMPLS = 'jina,reader';
+      vi.mocked(toolsEnv).CRAWLER_IMPLS = 'jina';
 
       const mockSuccessResult = {
         crawler: 'jina',
@@ -468,10 +468,10 @@ describe('SearchService', () => {
 
       await searchService.crawlPages({ urls: ['https://example.com'] });
 
-      expect(Crawler).toHaveBeenCalledWith({ impls: ['jina', 'reader'] });
+      expect(Crawler).toHaveBeenCalledWith({ impl: 'jina' });
     });
 
-    it('should pass impls parameter to crawler.crawl', async () => {
+    it.skip('should pass impls parameter to crawler.crawl', async () => {
       const mockSuccessResult = {
         crawler: 'jina',
         data: { content: 'ok', contentType: 'text' },

--- a/src/server/services/search/index.ts
+++ b/src/server/services/search/index.ts
@@ -4,7 +4,7 @@ import pMap from 'p-map';
 
 import { toolsEnv } from '@/envs/tools';
 
-import { type SearchImplType, type SearchServiceImpl } from './impls';
+import { SearchImplType, type SearchServiceImpl } from './impls';
 import { createSearchServiceImpl } from './impls';
 
 const DEFAULT_CRAWL_CONCURRENCY = 3;
@@ -21,7 +21,7 @@ const parseImplEnv = (envString: string = '') => {
  * Uses different implementations for different search operations
  */
 export class SearchService {
-  private searchImpList: SearchServiceImpl[];
+  private searchImpList: Array<{ type: SearchImplType; impl: SearchServiceImpl }>;
 
   private get crawlerImpls() {
     return parseImplEnv(toolsEnv.CRAWLER_IMPLS);
@@ -39,18 +39,29 @@ export class SearchService {
     const impls = this.searchImpls;
     this.searchImpList =
       impls.length > 0
-        ? impls.map((impl) => createSearchServiceImpl(impl))
-        : [createSearchServiceImpl()];
+        ? impls.map((impl) => ({ type: impl, impl: createSearchServiceImpl(impl) }))
+        : [{ type: SearchImplType.SearXNG, impl: createSearchServiceImpl() }];
   }
 
-  async crawlPages(input: { impls?: CrawlImplType[]; urls: string[] }) {
+  async crawlPages(input: { impls?: CrawlImplType[]; provider?: CrawlImplType; urls: string[] }) {
     const { Crawler } = await import('@lobechat/web-crawler');
-    const crawler = new Crawler({ impls: this.crawlerImpls });
+
+    // Determine which impl to use
+    let impl: CrawlImplType;
+    if (input.provider) {
+      impl = input.provider;
+    } else if (input.impls && input.impls.length > 0) {
+      impl = input.impls[0];
+    } else {
+      impl = (this.crawlerImpls[0] || 'naive') as CrawlImplType;
+    }
+
+    const crawler = new Crawler({ impl });
 
     const results = await pMap(
       input.urls,
       async (url) => {
-        return await this.crawlWithRetry(crawler, url, input.impls);
+        return await this.crawlWithRetry(crawler, url);
       },
       { concurrency: this.crawlConcurrency },
     );
@@ -58,18 +69,14 @@ export class SearchService {
     return { results };
   }
 
-  private async crawlWithRetry(
-    crawler: Crawler,
-    url: string,
-    impls?: CrawlImplType[],
-  ): Promise<CrawlUniformResult> {
+  private async crawlWithRetry(crawler: Crawler, url: string): Promise<CrawlUniformResult> {
     const maxAttempts = this.crawlerRetry + 1;
     let lastResult: CrawlUniformResult | undefined;
     let lastError: Error | undefined;
 
     for (let attempt = 1; attempt <= maxAttempts; attempt++) {
       try {
-        const result = await crawler.crawl({ impls, url });
+        const result = await crawler.crawl({ url });
         lastResult = result;
 
         if (!this.isFailedCrawlResult(result)) {
@@ -129,39 +136,46 @@ export class SearchService {
    * Query for search results (uses the first provider)
    */
   async query(query: string, params?: SearchParams) {
-    return this.queryWithImpl(this.searchImpList[0], query, params);
+    const impl = this.searchImpList[0]?.impl;
+    if (!impl) {
+      return { costTime: 0, query, resultNumbers: 0, results: [] };
+    }
+    return this.queryWithImpl(impl, query, params);
   }
 
-  async webSearch({ query, searchCategories, searchEngines, searchTimeRange }: SearchQuery) {
-    for (const impl of this.searchImpList) {
-      let data = await this.queryWithImpl(impl, query, {
-        searchCategories,
-        searchEngines,
-        searchTimeRange,
-      });
+  async webSearch({
+    query,
+    searchCategories,
+    searchEngines,
+    searchTimeRange,
+    provider,
+  }: SearchQuery) {
+    let implItem: { type: SearchImplType; impl: SearchServiceImpl } | undefined;
 
-      // First retry: remove search engine restrictions if no results found
-      if (data.results.length === 0 && searchEngines && searchEngines?.length > 0) {
-        data = await this.queryWithImpl(impl, query, {
-          searchCategories,
-          searchEngines: undefined,
-          searchTimeRange,
-        });
-      }
-
-      // Second retry: remove all restrictions if still no results found
-      if (data.results.length === 0) {
-        data = await this.queryWithImpl(impl, query);
-      }
-
-      // If this provider returned results, use them
-      if (data.results.length > 0) {
-        return data;
+    // If provider is specified, use that provider
+    if (provider) {
+      implItem = this.searchImpList.find((item) => item.type === provider);
+      if (!implItem) {
+        console.warn(
+          `[SearchService] Provider "${provider}" not found, using first available provider`,
+        );
       }
     }
 
-    // All providers exhausted, return empty result
-    return { costTime: 0, query, resultNumbers: 0, results: [] };
+    // Use the first available provider if no specific provider or not found
+    if (!implItem) {
+      implItem = this.searchImpList[0];
+    }
+
+    if (!implItem) {
+      return { costTime: 0, query, resultNumbers: 0, results: [] };
+    }
+
+    return await this.queryWithImpl(implItem.impl, query, {
+      searchCategories,
+      searchEngines,
+      searchTimeRange,
+    });
   }
 }
 


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

通过简化爬虫实现处理方式、增加显式的提供方选项，并将可用提供方暴露给网页浏览工具，以优化网页抓取和搜索提供方的选择。

新特性：
- 允许调用方通过在网页浏览工具清单和共享类型中新增的提供方字段，显式指定搜索和抓取提供方。
- 根据环境配置，将可用的搜索和抓取提供方暴露给网页浏览系统提示词。

改进：
- 简化爬虫逻辑，改为使用单一已配置的实现，并提供更清晰的错误报告，而不是在多个回退实现之间迭代尝试。
- 更新搜索服务，使其在实现旁边同时跟踪提供方类型，并在查询和网页搜索中确定性地选择单一提供方。
- 将默认爬虫和搜索提供方与基于环境驱动的配置及合理的回退策略对齐。
- 添加辅助工具，从环境变量中推导可用的搜索和抓取提供方，并将其接入网页浏览运行时。

测试：
- 调整爬虫单元测试以反映新的单一实现行为和默认提供方，并跳过那些不再符合简化流程的旧版搜索重试和多提供方相关测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine web crawling and search provider selection by simplifying crawler implementation handling, adding explicit provider options, and surfacing available providers to the web browsing tool.

New Features:
- Allow callers to specify search and crawl providers explicitly via new provider fields in web browsing tool manifests and shared types.
- Expose available search and crawl providers to the web browsing system prompt based on environment configuration.

Enhancements:
- Simplify the crawler to use a single configured implementation with clearer error reporting instead of iterating through multiple fallbacks.
- Update the search service to track provider types alongside implementations and to select a single provider deterministically for queries and web search.
- Align default crawler and search providers with environment-driven configuration and sensible fallbacks.
- Add helper utilities to derive available search and crawl providers from environment variables and wire them into the web browsing runtime.

Tests:
- Adjust crawler unit tests to reflect the new single-impl behavior and default provider, and skip legacy search retry and multi-provider tests that no longer match the simplified flow.

</details>