### PR TITLE
feat: add encrypted reasoning support

### DIFF
--- a/packages/model-runtime/src/core/contextBuilders/openai.ts
+++ b/packages/model-runtime/src/core/contextBuilders/openai.ts
@@ -78,6 +78,18 @@ export const convertOpenAIResponseInputs = async (
   const input: OpenAI.Responses.ResponseInputItem[] = [];
   await Promise.all(
     messages.map(async (message) => {
+      // if message has reasoning.encrypted_content, add it as a separate reasoning item
+      const reasoningData = message.reasoning as any;
+      if (reasoningData?.encrypted_content) {
+        input.push({
+          encrypted_content: reasoningData.encrypted_content,
+          id: reasoningData.id,
+          status: 'completed',
+          summary: reasoningData.summary || [],
+          type: 'reasoning',
+        } as any);
+      }
+
       // if message has reasoning, add it as a separate reasoning item
       if (message.reasoning?.content) {
         input.push({

--- a/packages/model-runtime/src/core/openaiCompatibleFactory/index.ts
+++ b/packages/model-runtime/src/core/openaiCompatibleFactory/index.ts
@@ -918,10 +918,18 @@ export const createOpenAICompatibleRuntime = <T extends Record<string, any> = an
 
       const inputStartAt = Date.now();
 
-      const { messages, reasoning_effort, tools, reasoning, responseMode, max_tokens, ...res } =
-        responses?.handlePayload
-          ? (responses?.handlePayload(payload, this._options) as ChatStreamPayload)
-          : payload;
+      const {
+        messages,
+        reasoning_effort,
+        tools,
+        reasoning,
+        responseMode,
+        max_tokens,
+        include,
+        ...res
+      } = responses?.handlePayload
+        ? (responses?.handlePayload(payload, this._options) as ChatStreamPayload)
+        : payload;
 
       // remove penalty params and chat completion specific params
       delete res.apiMode;
@@ -950,6 +958,7 @@ export const createOpenAICompatibleRuntime = <T extends Record<string, any> = an
               },
             }
           : {}),
+        include: include?.length ? include : undefined,
         input,
         ...(max_tokens && { max_output_tokens: max_tokens }),
         store: false,

--- a/packages/model-runtime/src/core/streams/openai/__snapshots__/responsesStream.test.ts.snap
+++ b/packages/model-runtime/src/core/streams/openai/__snapshots__/responsesStream.test.ts.snap
@@ -145,6 +145,53 @@ exports[`OpenAIResponsesStream > Reasoning > summary 1`] = `
 ]
 `;
 
+exports[`OpenAIResponsesStream > Reasoning Encrypted Content > should handle reasoning.encrypted_content from x.ai 1`] = `
+[
+  "id: resp_xai_reasoning
+",
+  "event: data
+",
+  "data: "in_progress"
+
+",
+  "id: resp_xai_reasoning
+",
+  "event: data
+",
+  "data: {"id":"rs_xai_reasoning_123","type":"reasoning","summary":[],"status":"in_progress"}
+
+",
+  "id: rs_xai_reasoning_123
+",
+  "event: reasoning_encrypted
+",
+  "data: {"id":"rs_xai_reasoning_123","type":"reasoning","summary":[],"status":"completed","encrypted_content":"g6LZZR+Ei+tsiEaKVvnh5fnpdOx71Cee/urDNIxYZTpuE3n0iAkj/E/796NZOOkKqkgNVMXUNPnQHMBVZrMbF/SQROCnvmKVT0WorULtR1YYa7cYcQmVzqTeahYCvhoVildmVF/nPh3czwIcsJ8zrvyiWq7K2+46jZXoBQN+JlBoAAR63qonlnz/WH0JqTR01v53biGOx2LEEWxKCdXEvYk3E//jC8wgnbP78BSfMASLkGSWEk6z2JytD7ZSqSRvByBSVg0FBnwEUG7QbxvkmIjBCvHdh/qRdZY6rodNQw+pGeLxbi5ixeuunE4fTyyYnuLs+NgpNo5IkMY2ZxOYoKkcpwBpyLvOYckHDyd0Bl1Vfj4PQm/1TdVR/QaEN1xfIPciImAE5VA0LMzXY64OeNTpP2zbBR3m3E8ItE4LaHdcbx1TL0Rpidy5NCY1yHTQg6ao53xWfrapUHTGFo7XRfxnUprfG+Vz6x8KzPggpCi2j6mgbYzkuPM05ZP9wyjbOmgnedPsSTfU2pUbxp0woJnwW3Css6IdLUVRd5957KrpiMD9gr2eq4ZlpkYsOlu3CPa8KrUboovZTx92KGmdkgdcqpME/wt8PuOFiOMSMOsqaqTgzJPnnutRvqz0zB9EzSF5rHfP3UK+R1YlAYQpkJE5/ocqyIOXLi9CcFI0b0EDYsEX8bd4oa/sXOeg9i3Mbf3XHpftg2sV/d8"}
+
+",
+  "id: resp_xai_reasoning
+",
+  "event: data
+",
+  "data: {"id":"msg_xai_123","type":"message","status":"in_progress","content":[],"role":"assistant"}
+
+",
+  "id: msg_xai_123
+",
+  "event: text
+",
+  "data: "Hello!"
+
+",
+  "id: resp_xai_reasoning
+",
+  "event: usage
+",
+  "data: {"inputCacheMissTokens":100,"inputTextTokens":100,"outputTextTokens":50,"totalInputTokens":100,"totalOutputTokens":50,"totalTokens":150}
+
+",
+]
+`;
+
 exports[`OpenAIResponsesStream > should handle chunks with undefined values gracefully 1`] = `
 [
   "id: resp_undefined_vals

--- a/packages/model-runtime/src/core/streams/openai/responsesStream.test.ts
+++ b/packages/model-runtime/src/core/streams/openai/responsesStream.test.ts
@@ -1373,4 +1373,77 @@ describe('OpenAIResponsesStream', () => {
       expect(onCompletionMock).toHaveBeenCalledTimes(1);
     });
   });
+
+  describe('Reasoning Encrypted Content', () => {
+    it('should handle reasoning.encrypted_content from x.ai', async () => {
+      const mockOpenAIStream = createReadableStream([
+        {
+          type: 'response.created',
+          response: {
+            id: 'resp_xai_reasoning',
+            status: 'in_progress',
+          },
+        },
+        {
+          type: 'response.output_item.added',
+          output_index: 0,
+          item: {
+            id: 'rs_xai_reasoning_123',
+            type: 'reasoning',
+            summary: [],
+            status: 'in_progress',
+          },
+        },
+        {
+          type: 'response.output_item.done',
+          output_index: 0,
+          item: {
+            id: 'rs_xai_reasoning_123',
+            type: 'reasoning',
+            summary: [],
+            status: 'completed',
+            encrypted_content:
+              'g6LZZR+Ei+tsiEaKVvnh5fnpdOx71Cee/urDNIxYZTpuE3n0iAkj/E/796NZOOkKqkgNVMXUNPnQHMBVZrMbF/SQROCnvmKVT0WorULtR1YYa7cYcQmVzqTeahYCvhoVildmVF/nPh3czwIcsJ8zrvyiWq7K2+46jZXoBQN+JlBoAAR63qonlnz/WH0JqTR01v53biGOx2LEEWxKCdXEvYk3E//jC8wgnbP78BSfMASLkGSWEk6z2JytD7ZSqSRvByBSVg0FBnwEUG7QbxvkmIjBCvHdh/qRdZY6rodNQw+pGeLxbi5ixeuunE4fTyyYnuLs+NgpNo5IkMY2ZxOYoKkcpwBpyLvOYckHDyd0Bl1Vfj4PQm/1TdVR/QaEN1xfIPciImAE5VA0LMzXY64OeNTpP2zbBR3m3E8ItE4LaHdcbx1TL0Rpidy5NCY1yHTQg6ao53xWfrapUHTGFo7XRfxnUprfG+Vz6x8KzPggpCi2j6mgbYzkuPM05ZP9wyjbOmgnedPsSTfU2pUbxp0woJnwW3Css6IdLUVRd5957KrpiMD9gr2eq4ZlpkYsOlu3CPa8KrUboovZTx92KGmdkgdcqpME/wt8PuOFiOMSMOsqaqTgzJPnnutRvqz0zB9EzSF5rHfP3UK+R1YlAYQpkJE5/ocqyIOXLi9CcFI0b0EDYsEX8bd4oa/sXOeg9i3Mbf3XHpftg2sV/d8',
+          },
+        },
+        {
+          type: 'response.output_item.added',
+          output_index: 1,
+          item: {
+            id: 'msg_xai_123',
+            type: 'message',
+            status: 'in_progress',
+            content: [],
+            role: 'assistant',
+          },
+        },
+        {
+          type: 'response.output_text.delta',
+          item_id: 'msg_xai_123',
+          delta: 'Hello!',
+        },
+        {
+          type: 'response.completed',
+          response: {
+            id: 'resp_xai_reasoning',
+            status: 'completed',
+            usage: {
+              input_tokens: 100,
+              output_tokens: 50,
+              total_tokens: 150,
+            },
+          },
+        },
+      ]);
+
+      const protocolStream = OpenAIResponsesStream(mockOpenAIStream, {
+        payload: { model: 'grok-4-1-fast-reasoning', provider: 'xai' },
+      });
+      const chunks = await readStreamChunk(protocolStream);
+
+      expect(chunks).toMatchSnapshot();
+      expect(chunks.some((c) => c.includes('event: reasoning_encrypted'))).toBe(true);
+      expect(chunks.some((c) => c.includes('encrypted_content'))).toBe(true);
+    });
+  });
 });

--- a/packages/model-runtime/src/core/streams/openai/responsesStream.ts
+++ b/packages/model-runtime/src/core/streams/openai/responsesStream.ts
@@ -145,6 +145,14 @@ const transformOpenAIStream = (
       }
 
       case 'response.output_item.done': {
+        if (chunk.item.type === 'reasoning' && 'encrypted_content' in chunk.item) {
+          return {
+            data: chunk.item,
+            id: chunk.item.id,
+            type: 'reasoning_encrypted',
+          };
+        }
+
         if (streamContext.returnedCitationArray?.length) {
           return {
             data: { citations: streamContext.returnedCitationArray },

--- a/packages/model-runtime/src/core/streams/protocol.ts
+++ b/packages/model-runtime/src/core/streams/protocol.ts
@@ -78,6 +78,8 @@ export interface StreamProtocolChunk {
     | 'tool_calls'
     // Model Thinking
     | 'reasoning'
+    // encrypted reasoning content
+    | 'reasoning_encrypted'
     // use for reasoning signature, maybe only anthropic
     | 'reasoning_signature'
     // flagged reasoning signature
@@ -262,6 +264,14 @@ export function createCallbacksTransformer(cb: ChatStreamCallbacks | undefined) 
   const textEncoder = new TextEncoder();
   let aggregatedText = '';
   let aggregatedThinking: string | undefined = undefined;
+  let reasoningEncrypted:
+    | {
+        encrypted_content: string;
+        id: string;
+        summary?: any[];
+        type: 'reasoning';
+      }
+    | undefined;
   let usage: ModelUsage | undefined;
   let speed: ModelPerformance | undefined;
   let grounding: any;
@@ -278,6 +288,7 @@ export function createCallbacksTransformer(cb: ChatStreamCallbacks | undefined) 
       const data = {
         error: streamError,
         grounding,
+        reasoningEncrypted,
         speed,
         text: aggregatedText,
         thinking: aggregatedThinking,
@@ -327,6 +338,12 @@ export function createCallbacksTransformer(cb: ChatStreamCallbacks | undefined) 
 
             aggregatedThinking += data;
             await callbacks.onThinking?.(data);
+            break;
+          }
+
+          case 'reasoning_encrypted': {
+            reasoningEncrypted = data;
+            await callbacks.onReasoningEncrypted?.(data);
             break;
           }
 

--- a/packages/model-runtime/src/providers/xai/index.test.ts
+++ b/packages/model-runtime/src/providers/xai/index.test.ts
@@ -116,6 +116,40 @@ describe('LobeXAI - custom features', () => {
       const createCall = (instance['client'].responses.create as Mock).mock.calls[0][0];
       expect(createCall.tools).toEqual([{ type: 'web_search' }, { type: 'x_search' }]);
     });
+
+    it('should include reasoning.encrypted_content by default', async () => {
+      await instance.chat({
+        messages: [{ content: 'Hello', role: 'user' }],
+        model: 'grok-4-1-fast-reasoning',
+        apiMode: 'responses',
+      });
+
+      const createCall = (instance['client'].responses.create as Mock).mock.calls[0][0];
+      expect(createCall.include).toEqual(['reasoning.encrypted_content']);
+    });
+
+    it('should use existing include array if provided', async () => {
+      await instance.chat({
+        messages: [{ content: 'Hello', role: 'user' }],
+        model: 'grok-4-1-fast-reasoning',
+        apiMode: 'responses',
+        include: ['reasoning.summary'],
+      });
+
+      const createCall = (instance['client'].responses.create as Mock).mock.calls[0][0];
+      expect(createCall.include).toEqual(['reasoning.summary']);
+    });
+
+    it('should include reasoning.encrypted_content if include is empty array', async () => {
+      await instance.chat({
+        messages: [{ content: 'Hello', role: 'user' }],
+        model: 'grok-4-1-fast-reasoning',
+        apiMode: 'responses',
+      });
+
+      const createCall = (instance['client'].responses.create as Mock).mock.calls[0][0];
+      expect(createCall.include).toEqual(['reasoning.encrypted_content']);
+    });
   });
 
   describe('models', () => {

--- a/packages/model-runtime/src/providers/xai/index.ts
+++ b/packages/model-runtime/src/providers/xai/index.ts
@@ -55,6 +55,7 @@ export const LobeXAI = createOpenAICompatibleRuntime({
 
       return {
         ...rest,
+        include: ['reasoning.encrypted_content'],
         stream: payload.stream ?? true,
         tools: xaiTools,
       } as any;

--- a/packages/model-runtime/src/types/chat.ts
+++ b/packages/model-runtime/src/types/chat.ts
@@ -84,6 +84,10 @@ export interface ChatStreamPayload {
    */
   imageResolution?: '1K' | '2K' | '4K';
   /**
+   * Additional options to include in the response (for Responses API)
+   */
+  include?: string[];
+  /**
    * @title Maximum length of generated text
    */
   max_tokens?: number;
@@ -218,6 +222,12 @@ export interface ChatCompletionTool {
 export interface OnFinishData {
   error?: any;
   grounding?: any;
+  reasoningEncrypted?: {
+    encrypted_content: string;
+    id: string;
+    summary?: any[];
+    type: 'reasoning';
+  };
   speed?: ModelPerformance;
   text: string;
   thinking?: string;
@@ -273,6 +283,11 @@ export interface ChatStreamCallbacks {
    **/
   onFinal?: (data: OnFinishData) => Promise<void> | void;
   onGrounding?: (grounding: any) => Promise<void> | void;
+  /**
+   * `onReasoningEncrypted`: Called when encrypted reasoning content is received.
+   * Used for models that return encrypted reasoning data (e.g., x.ai grok reasoning models)
+   */
+  onReasoningEncrypted?: (data: { encrypted_content: string }) => Promise<void> | void;
   /**
    * `onReasoningPart`: Called for each reasoning/thinking part in multimodal output.
    * Used for models that return structured reasoning with mixed text and images.

--- a/src/server/modules/AgentRuntime/RuntimeExecutors.ts
+++ b/src/server/modules/AgentRuntime/RuntimeExecutors.ts
@@ -117,6 +117,14 @@ export const createRuntimeExecutors = (
       let toolsCalling: ChatToolPayload[] = [];
       let tool_calls: MessageToolCall[] = [];
       let thinkingContent = '';
+      let reasoningEncrypted:
+        | {
+            encrypted_content: string;
+            id: string;
+            summary?: any[];
+            type: 'reasoning';
+          }
+        | undefined;
       const imageList: any[] = [];
       let grounding: any = null;
       let currentStepUsage: any = undefined;
@@ -285,6 +293,17 @@ export const createRuntimeExecutors = (
             // Capture usage (may or may not include cost)
             if (data.usage) {
               currentStepUsage = data.usage;
+            }
+          },
+          onFinal: async (data) => {
+            // Capture reasoning encrypted content for multi-turn conversation
+            if (data.reasoningEncrypted) {
+              reasoningEncrypted = data.reasoningEncrypted;
+              log(
+                `[${operationLogId}][reasoningEncrypted] captured, id: %s, length: %d`,
+                reasoningEncrypted.id,
+                reasoningEncrypted.encrypted_content.length,
+              );
             }
           },
           onGrounding: async (groundingData) => {
@@ -468,7 +487,7 @@ export const createRuntimeExecutors = (
           content: finalContent,
           imageList: imageList.length > 0 ? imageList : undefined,
           metadata: Object.keys(metadata).length > 0 ? metadata : undefined,
-          reasoning: finalReasoning,
+          reasoning: reasoningEncrypted || finalReasoning || undefined,
           search: grounding,
           tools: toolsCalling.length > 0 ? toolsCalling : undefined,
         });

--- a/src/server/modules/AgentRuntime/RuntimeExecutors.ts
+++ b/src/server/modules/AgentRuntime/RuntimeExecutors.ts
@@ -500,6 +500,7 @@ export const createRuntimeExecutors = (
 
       newState.messages.push({
         content,
+        reasoning: reasoningEncrypted || finalReasoning || undefined,
         role: 'assistant',
         tool_calls: tool_calls.length > 0 ? tool_calls : undefined,
       });


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

在流式传输、路由和 provider 运行时中新增对加密推理内容的支持，包括对 x.ai 推理模型的默认处理。

新功能：
- 引入新的 `reasoning_encrypted` 流事件类型和回调，用于从各个 provider 暴露加密推理内容。
- 支持通过聊天负载将 `include` 选项传递给 Responses API，以实现对推理输出的精细控制。
- 允许运行时执行器在多轮对话中捕获并持久化加密推理内容，在存在加密内容时优先于明文推理内容。
- 允许 OpenAI 兼容的上下文构建在先前消息中提供加密推理条目时，将其发送回模型。
- 默认将 x.ai 推理模型配置为请求加密推理内容，同时尊重任何显式的 include 配置。

测试：
- 添加流式测试和快照，以验证来自 x.ai Responses API 流的 `reasoning_encrypted` 处理。
- 扩展 x.ai provider 测试，覆盖加密推理内容的默认和自定义 `include` 行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for encrypted reasoning content in streaming, routing, and provider runtimes, including default handling for x.ai reasoning models.

New Features:
- Introduce a new `reasoning_encrypted` stream event type and callback to surface encrypted reasoning content from providers.
- Support passing `include` options through chat payloads to the Responses API for fine-grained reasoning output control.
- Enable runtime executors to capture and persist encrypted reasoning content across turns, preferring it over plain reasoning when present.
- Allow OpenAI-compatible context building to send encrypted reasoning items back to the model when provided in prior messages.
- Default x.ai reasoning models to request encrypted reasoning content while respecting any explicit include configuration.

Tests:
- Add streaming tests and snapshots to verify `reasoning_encrypted` handling from x.ai Responses API streams.
- Extend x.ai provider tests to cover default and custom `include` behavior for encrypted reasoning content.

</details>