### PR TITLE
feat: add encrypted reasoning support

### DIFF
--- a/packages/model-runtime/src/core/contextBuilders/openai.test.ts
+++ b/packages/model-runtime/src/core/contextBuilders/openai.test.ts
@@ -444,6 +444,42 @@ describe('convertOpenAIResponseInputs', () => {
       },
     ]);
   });
+
+  it('should handle encrypted reasoning content with id', async () => {
+    const messages: OpenAIChatMessage[] = [
+      { content: 'system prompts', role: 'system' },
+      {
+        content: 'What is meaning of life?',
+        role: 'user',
+      },
+      {
+        content: '42',
+        role: 'assistant',
+        reasoning: {
+          encryptedContent:
+            'bvV88j99ILvgfHRTHCUSJtw+ISji6txJzPdZNbcSVuDk4OMG2Z9r5wOBBwjd3u3Hhm9XtpCWJO1YgTOlpgbn+g7DZX+pOagYYrCFUpQ19XkWz6Je8bHG9JcSDoGDqNgRbDbAUO8at6RCyqgPupJj5ArBDCt73fGQLTC4G3S0JMK9LsPiWz6GPj6qyzYoRzkj4R6bntRm74E4h8Y+z6u6B7+ixPSv8s1EFs8c+NUAB8TNKZZpXZquj2LXfx1xAie85Syl7qLqxLNtDG1dNBhBnHpYoE4gQzwyXqywf5pF2Q2imzPNzGQhurK+6gaNWgZbxRmjhdsW6TnzO5Kk6pzb5qpfgfcEScQeYHSj5GpD+yDUCNlhdbzhhWnEErH+wuBPpTG6UQhiC7m7yrJ7IY2E8K/BeUPlUvkhMaMwb4dA279pWMJdchNJ+TAxca+JVc80pXMG/PmrQUNJU9qdXRLbNmQbRadBNwV2qkPfgggL3q0yNd7Un9P+atmP3B9keBILif3ufsBDtVUobEniiyGV7YVDvQ/fQRVs7XDxJiOKkogjjQySyHgpjseO8iG5xtb9mrz6B3mDvv2aAuyDL6MHZRM7QDVPjUbgNMzDm5Sm3J7IhtzfR+3eMDws3qeTsxOt1KOslu983Btv1Wx37b5HJqX1pQU1dae/kOSJ7MifFd6wMkQtQBDgVoG3ka9wq5Vxq9Ki8bDOOMcwA2kUXhCcY3TZCXJfDWSKPTcCoNCYIv5LT2NFVdamiSfLIyeOjBNz459BfMvAoOZShFViQyc5YwjnReUQPQ8a18jcz8GoAK1O99e0h91oYxIgDV52EfS+IYrzqvJOEQbKQinB+LJwkPbBEp7ZtgAtiNBzm985hNgLfiBaVFWcRYwI3tNBCT1vkw2YI0NEEG0yOF29x+u64XzqyP1CX1pU6sGXEFn3RPdfYibf6bt/Y1BRqBL5l0CrXWsgDw02SqIFta8OvJ7Iwmq40/4acE/Ew6eWO/z2MHkWgqSpwGNjn7MfeKkTi44foZjfNqN9QOFQt6VG2tY+biKZDo0h9DAftae8Q2Xs2UDvsBYOm7YEahVkput6/uKzxljpXlz269qHk6ckvdN9hKLbaTO3/IZPCCPQ5a/a/sWn/1VOJj72sDk+23RNjBf0FL6bJMXZI5aQdtxbF1zij9mWcP9nJ9FHhj53ytuf1NiKl5xU8ZsaoKmCAJcXUz1n2FZvyWlqvgPYiszc7R8Y5dF6QbW2mlKnXzVy6qRMHNeQqGhCEncyT5nPNSdK5QlUwLokAIg',
+          id: 'rs_51abe1aa-599b-80b6-57c8-dddc6263362f_us-east-1',
+        },
+      },
+    ];
+    const result = await convertOpenAIResponseInputs(messages);
+    expect(result).toEqual([
+      { content: 'system prompts', role: 'developer' },
+      { content: 'What is meaning of life?', role: 'user' },
+      {
+        encrypted_content:
+          'bvV88j99ILvgfHRTHCUSJtw+ISji6txJzPdZNbcSVuDk4OMG2Z9r5wOBBwjd3u3Hhm9XtpCWJO1YgTOlpgbn+g7DZX+pOagYYrCFUpQ19XkWz6Je8bHG9JcSDoGDqNgRbDbAUO8at6RCyqgPupJj5ArBDCt73fGQLTC4G3S0JMK9LsPiWz6GPj6qyzYoRzkj4R6bntRm74E4h8Y+z6u6B7+ixPSv8s1EFs8c+NUAB8TNKZZpXZquj2LXfx1xAie85Syl7qLqxLNtDG1dNBhBnHpYoE4gQzwyXqywf5pF2Q2imzPNzGQhurK+6gaNWgZbxRmjhdsW6TnzO5Kk6pzb5qpfgfcEScQeYHSj5GpD+yDUCNlhdbzhhWnEErH+wuBPpTG6UQhiC7m7yrJ7IY2E8K/BeUPlUvkhMaMwb4dA279pWMJdchNJ+TAxca+JVc80pXMG/PmrQUNJU9qdXRLbNmQbRadBNwV2qkPfgggL3q0yNd7Un9P+atmP3B9keBILif3ufsBDtVUobEniiyGV7YVDvQ/fQRVs7XDxJiOKkogjjQySyHgpjseO8iG5xtb9mrz6B3mDvv2aAuyDL6MHZRM7QDVPjUbgNMzDm5Sm3J7IhtzfR+3eMDws3qeTsxOt1KOslu983Btv1Wx37b5HJqX1pQU1dae/kOSJ7MifFd6wMkQtQBDgVoG3ka9wq5Vxq9Ki8bDOOMcwA2kUXhCcY3TZCXJfDWSKPTcCoNCYIv5LT2NFVdamiSfLIyeOjBNz459BfMvAoOZShFViQyc5YwjnReUQPQ8a18jcz8GoAK1O99e0h91oYxIgDV52EfS+IYrzqvJOEQbKQinB+LJwkPbBEp7ZtgAtiNBzm985hNgLfiBaVFWcRYwI3tNBCT1vkw2YI0NEEG0yOF29x+u64XzqyP1CX1pU6sGXEFn3RPdfYibf6bt/Y1BRqBL5l0CrXWsgDw02SqIFta8OvJ7Iwmq40/4acE/Ew6eWO/z2MHkWgqSpwGNjn7MfeKkTi44foZjfNqN9QOFQt6VG2tY+biKZDo0h9DAftae8Q2Xs2UDvsBYOm7YEahVkput6/uKzxljpXlz269qHk6ckvdN9hKLbaTO3/IZPCCPQ5a/a/sWn/1VOJj72sDk+23RNjBf0FL6bJMXZI5aQdtxbF1zij9mWcP9nJ9FHhj53ytuf1NiKl5xU8ZsaoKmCAJcXUz1n2FZvyWlqvgPYiszc7R8Y5dF6QbW2mlKnXzVy6qRMHNeQqGhCEncyT5nPNSdK5QlUwLokAIg',
+        id: 'rs_51abe1aa-599b-80b6-57c8-dddc6263362f_us-east-1',
+        status: 'completed',
+        summary: [],
+        type: 'reasoning',
+      },
+      {
+        content: '42',
+        role: 'assistant',
+      },
+    ]);
+  });
 });
 
 describe('convertImageUrlToFile', () => {

--- a/packages/model-runtime/src/core/contextBuilders/openai.ts
+++ b/packages/model-runtime/src/core/contextBuilders/openai.ts
@@ -78,6 +78,17 @@ export const convertOpenAIResponseInputs = async (
   const input: OpenAI.Responses.ResponseInputItem[] = [];
   await Promise.all(
     messages.map(async (message) => {
+      // if message has encrypted reasoning content, add it as a separate reasoning item
+      if (message.reasoning?.encryptedContent) {
+        input.push({
+          encrypted_content: message.reasoning.encryptedContent,
+          id: message.reasoning.id,
+          status: 'completed',
+          summary: [],
+          type: 'reasoning',
+        } as OpenAI.Responses.ResponseReasoningItem);
+      }
+
       // if message has reasoning, add it as a separate reasoning item
       if (message.reasoning?.content) {
         input.push({

--- a/packages/model-runtime/src/core/streams/openai/__snapshots__/responsesStream.test.ts.snap
+++ b/packages/model-runtime/src/core/streams/openai/__snapshots__/responsesStream.test.ts.snap
@@ -164,6 +164,32 @@ exports[`OpenAIResponsesStream > should handle chunks with undefined values grac
 ]
 `;
 
+exports[`OpenAIResponsesStream > should handle encrypted reasoning content in response.output_item.done 1`] = `
+[
+  "id: resp_encrypted
+",
+  "event: data
+",
+  "data: "in_progress"
+
+",
+  "id: resp_encrypted
+",
+  "event: data
+",
+  "data: {"id":"rs_encrypted_123","type":"reasoning","summary":[]}
+
+",
+  "id: rs_encrypted_123
+",
+  "event: encrypted_reasoning
+",
+  "data: "g6LZZR+Ei+tsiEaKVvnh5fnpdOx71Cee/urDNIxYZTpuE3n0iAkj/E/796NZOOkKqkgNVMXUNPnQHMBVZrMbF/SQROCnvmKVT0WorULtR1YYa7cYcQmVzqTeahYCvhoVildmVF/nPh3czwIcsJ8zrvyiWq7K2+46jZXoBQN+JlBoAAR63qonlnz/WH0JqTR01v53biGOx2LEEWxKCdXEvYk3E//jC8wgnbP78BSfMASLkGSWEk6z2JytD7ZSqSRvByBSVg0FBnwEUG7QbxvkmIjBCvHdh/qRdZY6rodNQw+pGeLxbi5ixeuunE4fTyyYnuLs+NgpNo5IkMY2ZxOYoKkcpwBpyLvOYckHDyd0Bl1Vfj4PQm/1TdVR/QaEN1xfIPciImAE5VA0LMzXY64OeNTpP2zbBR3m3E8ItE4LaHdcbx1TL0Rpidy5NCY1yHTQg6ao53xWfrapUHTGFo7XRfxnUprfG+Vz6x8KzPggpCi2j6mgbYzkuPM05ZP9wyjbOmgnedPsSTfU2pUbxp0woJnwW3Css6IdLUVRd5957KrpiMD9gr2eq4ZlpkYsOlu3CPa8KrUboovZTx92KGmdkgdcqpME/wt8PuOFiOMSMOsqaqTgzJPnnutRvqz0zB9EzSF5rHfP3UK+R1YlAYQpkJE5/ocqyIOXLi9CcFI0b0EDYsEX8bd4oa/sXOeg9i3Mbf3XHpftg2sV/d8"
+
+",
+]
+`;
+
 exports[`OpenAIResponsesStream > should handle first chunk error with FIRST_CHUNK_ERROR_KEY 1`] = `
 [
   "id: first_chunk_error

--- a/packages/model-runtime/src/core/streams/openai/responsesStream.test.ts
+++ b/packages/model-runtime/src/core/streams/openai/responsesStream.test.ts
@@ -1373,4 +1373,49 @@ describe('OpenAIResponsesStream', () => {
       expect(onCompletionMock).toHaveBeenCalledTimes(1);
     });
   });
+
+  it('should handle encrypted reasoning content in response.output_item.done', async () => {
+    const mockOpenAIStream = createReadableStream([
+      {
+        type: 'response.created',
+        response: {
+          id: 'resp_encrypted',
+          status: 'in_progress',
+        },
+      },
+      {
+        type: 'response.output_item.added',
+        output_index: 0,
+        item: {
+          id: 'rs_encrypted_123',
+          type: 'reasoning',
+          summary: [],
+        },
+      },
+      {
+        type: 'response.output_item.done',
+        output_index: 0,
+        item: {
+          id: 'rs_encrypted_123',
+          type: 'reasoning',
+          status: 'completed',
+          encrypted_content:
+            'g6LZZR+Ei+tsiEaKVvnh5fnpdOx71Cee/urDNIxYZTpuE3n0iAkj/E/796NZOOkKqkgNVMXUNPnQHMBVZrMbF/SQROCnvmKVT0WorULtR1YYa7cYcQmVzqTeahYCvhoVildmVF/nPh3czwIcsJ8zrvyiWq7K2+46jZXoBQN+JlBoAAR63qonlnz/WH0JqTR01v53biGOx2LEEWxKCdXEvYk3E//jC8wgnbP78BSfMASLkGSWEk6z2JytD7ZSqSRvByBSVg0FBnwEUG7QbxvkmIjBCvHdh/qRdZY6rodNQw+pGeLxbi5ixeuunE4fTyyYnuLs+NgpNo5IkMY2ZxOYoKkcpwBpyLvOYckHDyd0Bl1Vfj4PQm/1TdVR/QaEN1xfIPciImAE5VA0LMzXY64OeNTpP2zbBR3m3E8ItE4LaHdcbx1TL0Rpidy5NCY1yHTQg6ao53xWfrapUHTGFo7XRfxnUprfG+Vz6x8KzPggpCi2j6mgbYzkuPM05ZP9wyjbOmgnedPsSTfU2pUbxp0woJnwW3Css6IdLUVRd5957KrpiMD9gr2eq4ZlpkYsOlu3CPa8KrUboovZTx92KGmdkgdcqpME/wt8PuOFiOMSMOsqaqTgzJPnnutRvqz0zB9EzSF5rHfP3UK+R1YlAYQpkJE5/ocqyIOXLi9CcFI0b0EDYsEX8bd4oa/sXOeg9i3Mbf3XHpftg2sV/d8',
+        },
+      },
+    ]);
+
+    const protocolStream = OpenAIResponsesStream(mockOpenAIStream);
+    const chunks = await readStreamChunk(protocolStream);
+
+    expect(chunks).toMatchSnapshot();
+    expect(chunks.some((c) => c.includes('event: encrypted_reasoning'))).toBe(true);
+    expect(
+      chunks.some((c) =>
+        c.includes(
+          'g6LZZR+Ei+tsiEaKVvnh5fnpdOx71Cee/urDNIxYZTpuE3n0iAkj/E/796NZOOkKqkgNVMXUNPnQHMBVZrMbF/SQROCnvmKVT0WorULtR1YYa7cYcQmVzqTeahYCvhoVildmVF/nPh3czwIcsJ8zrvyiWq7K2+46jZXoBQN+JlBoAAR63qonlnz/WH0JqTR01v53biGOx2LEEWxKCdXEvYk3E//jC8wgnbP78BSfMASLkGSWEk6z2JytD7ZSqSRvByBSVg0FBnwEUG7QbxvkmIjBCvHdh/qRdZY6rodNQw+pGeLxbi5ixeuunE4fTyyYnuLs+NgpNo5IkMY2ZxOYoKkcpwBpyLvOYckHDyd0Bl1Vfj4PQm/1TdVR/QaEN1xfIPciImAE5VA0LMzXY64OeNTpP2zbBR3m3E8ItE4LaHdcbx1TL0Rpidy5NCY1yHTQg6ao53xWfrapUHTGFo7XRfxnUprfG+Vz6x8KzPggpCi2j6mgbYzkuPM05ZP9wyjbOmgnedPsSTfU2pUbxp0woJnwW3Css6IdLUVRd5957KrpiMD9gr2eq4ZlpkYsOlu3CPa8KrUboovZTx92KGmdkgdcqpME/wt8PuOFiOMSMOsqaqTgzJPnnutRvqz0zB9EzSF5rHfP3UK+R1YlAYQpkJE5/ocqyIOXLi9CcFI0b0EDYsEX8bd4oa/sXOeg9i3Mbf3XHpftg2sV/d8',
+        ),
+      ),
+    ).toBe(true);
+  });
 });

--- a/packages/model-runtime/src/core/streams/openai/responsesStream.ts
+++ b/packages/model-runtime/src/core/streams/openai/responsesStream.ts
@@ -145,6 +145,19 @@ const transformOpenAIStream = (
       }
 
       case 'response.output_item.done': {
+        // Handle encrypted reasoning content for reasoning items
+        if (
+          chunk.item.type === 'reasoning' &&
+          'encrypted_content' in chunk.item &&
+          chunk.item.encrypted_content
+        ) {
+          return {
+            data: chunk.item.encrypted_content,
+            id: chunk.item.id,
+            type: 'encrypted_reasoning',
+          };
+        }
+
         if (streamContext.returnedCitationArray?.length) {
           return {
             data: { citations: streamContext.returnedCitationArray },

--- a/packages/model-runtime/src/core/streams/protocol.ts
+++ b/packages/model-runtime/src/core/streams/protocol.ts
@@ -96,6 +96,8 @@ export interface StreamProtocolChunk {
     | 'usage'
     // performance monitor
     | 'speed'
+    // encrypted reasoning content (e.g., from xai/grok)
+    | 'encrypted_reasoning'
     // unknown data result
     | 'data';
 }
@@ -262,6 +264,7 @@ export function createCallbacksTransformer(cb: ChatStreamCallbacks | undefined) 
   const textEncoder = new TextEncoder();
   let aggregatedText = '';
   let aggregatedThinking: string | undefined = undefined;
+  let encryptedReasoning: string | undefined = undefined;
   let usage: ModelUsage | undefined;
   let speed: ModelPerformance | undefined;
   let grounding: any;
@@ -281,6 +284,7 @@ export function createCallbacksTransformer(cb: ChatStreamCallbacks | undefined) 
         speed,
         text: aggregatedText,
         thinking: aggregatedThinking,
+        encryptedReasoning,
         toolsCalling,
         usage,
       };
@@ -327,6 +331,11 @@ export function createCallbacksTransformer(cb: ChatStreamCallbacks | undefined) 
 
             aggregatedThinking += data;
             await callbacks.onThinking?.(data);
+            break;
+          }
+
+          case 'encrypted_reasoning': {
+            encryptedReasoning = data;
             break;
           }
 

--- a/packages/model-runtime/src/types/chat.ts
+++ b/packages/model-runtime/src/types/chat.ts
@@ -1,4 +1,9 @@
-import type { ModelPerformance, ModelTokensUsage, ModelUsage } from '@lobechat/types';
+import type {
+  ModelPerformance,
+  ModelReasoning,
+  ModelTokensUsage,
+  ModelUsage,
+} from '@lobechat/types';
 
 import type { MessageToolCall, MessageToolCallChunk } from './toolsCalling';
 
@@ -47,10 +52,7 @@ export type UserMessageContentPart =
 export interface OpenAIChatMessage {
   content: string | UserMessageContentPart[];
   name?: string;
-  reasoning?: {
-    content?: string;
-    duration?: number;
-  };
+  reasoning?: ModelReasoning;
   role: LLMRoleType;
   tool_call_id?: string;
   tool_calls?: MessageToolCall[];
@@ -216,6 +218,7 @@ export interface ChatCompletionTool {
 }
 
 export interface OnFinishData {
+  encryptedReasoning?: string;
   error?: any;
   grounding?: any;
   speed?: ModelPerformance;

--- a/packages/types/src/message/common/base.ts
+++ b/packages/types/src/message/common/base.ts
@@ -50,6 +50,14 @@ export interface ModelReasoning {
   content?: string;
   duration?: number;
   /**
+   * Encrypted reasoning content from API responses
+   */
+  encryptedContent?: string;
+  /**
+   * Reasoning item ID for Responses API
+   */
+  id?: string;
+  /**
    * Flag indicating if content is multimodal (serialized MessageContentPart[])
    */
   isMultimodal?: boolean;
@@ -62,4 +70,5 @@ export const ModelReasoningSchema = z.object({
   duration: z.number().optional(),
   isMultimodal: z.boolean().optional(),
   signature: z.string().optional(),
+  encryptedContent: z.string().optional(),
 });

--- a/src/store/chat/agents/StreamingHandler.ts
+++ b/src/store/chat/agents/StreamingHandler.ts
@@ -53,6 +53,8 @@ export class StreamingHandler {
   private thinkingDuration?: number;
   private reasoningOperationId?: string;
   private reasoningParts: MessageContentPart[] = [];
+  private encryptedReasoningContent?: string;
+  private encryptedReasoningId?: string;
 
   // ========== Multimodal state ==========
   private contentParts: MessageContentPart[] = [];
@@ -101,6 +103,10 @@ export class StreamingHandler {
       }
       case 'reasoning': {
         this.handleReasoningChunk(chunk);
+        break;
+      }
+      case 'encrypted_reasoning': {
+        this.handleEncryptedReasoningChunk(chunk);
         break;
       }
       case 'reasoning_part': {
@@ -223,6 +229,21 @@ export class StreamingHandler {
     this.thinkingContent += chunk.text;
 
     this.callbacks.onReasoningUpdate({ content: this.thinkingContent });
+  }
+
+  private handleEncryptedReasoningChunk(chunk: {
+    encryptedContent: string;
+    id: string;
+    type: 'encrypted_reasoning';
+  }): void {
+    // Store encrypted reasoning content and id
+    this.encryptedReasoningContent = chunk.encryptedContent;
+    this.encryptedReasoningId = chunk.id;
+
+    // Update reasoning state with encrypted content
+    this.callbacks.onReasoningUpdate({
+      encryptedContent: this.encryptedReasoningContent,
+    });
   }
 
   private handleReasoningPartChunk(chunk: {
@@ -502,6 +523,15 @@ export class StreamingHandler {
       finalReasoning = {
         ...finishData.reasoning,
         duration: finalDuration,
+      };
+    }
+
+    // Add encrypted reasoning content if present
+    if (this.encryptedReasoningContent) {
+      finalReasoning = {
+        ...finalReasoning,
+        encryptedContent: this.encryptedReasoningContent,
+        id: this.encryptedReasoningId,
       };
     }
 

--- a/src/store/chat/agents/types/streaming.ts
+++ b/src/store/chat/agents/types/streaming.ts
@@ -25,6 +25,14 @@ export interface StreamingContext {
 export interface ReasoningState {
   content?: string;
   duration?: number;
+  /**
+   * Encrypted reasoning content from API responses
+   */
+  encryptedContent?: string;
+  /**
+   * Reasoning item ID for Responses API
+   */
+  id?: string;
   isMultimodal?: boolean;
   signature?: string;
   tempDisplayContent?: MessageContentPart[];
@@ -69,6 +77,7 @@ export interface StreamingCallbacks {
  * Finish callback data
  */
 export interface FinishData {
+  encryptedReasoning?: string;
   grounding?: GroundingData;
   observationId?: string | null;
   reasoning?: { content?: string; signature?: string };
@@ -120,4 +129,5 @@ export type StreamChunk =
       images: { data: string; id: string }[];
       type: 'base64_image';
     }
+  | { encryptedContent: string; id: string; type: 'encrypted_reasoning' }
   | { type: 'stop' };


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

在 OpenAI 流式传输、上下文构建和聊天处理流程中，新增对加密推理内容的处理支持。

新功能：
- 从 OpenAI Responses API 的流式响应中获取并输出加密推理项，作为专门的 `encrypted_reasoning` 分片类型。
- 在聊天流式处理器和推理状态中捕获并传递加密推理内容及其 ID。
- 在 OpenAI 聊天消息中接受加密推理元数据，并将其转换为适用于 Responses API 的推理项。

测试：
- 新增单元测试，用于验证在 OpenAI 响应流和响应输入转换过程中对加密推理内容的处理逻辑。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for handling encrypted reasoning content across OpenAI streaming, context building, and chat handling.

New Features:
- Stream and surface encrypted reasoning items from OpenAI Responses API as a dedicated encrypted_reasoning chunk type.
- Capture and propagate encrypted reasoning content and IDs through the chat streaming handler and reasoning state.
- Accept encrypted reasoning metadata on OpenAI chat messages and convert it into reasoning items for the Responses API.

Tests:
- Add unit tests to verify encrypted reasoning handling in OpenAI response streams and response input conversion.

</details>