### PR TITLE
✨ feat: add encrypted_content support for OpenAI Response API

### DIFF
--- a/packages/model-runtime/src/core/contextBuilders/openai.ts
+++ b/packages/model-runtime/src/core/contextBuilders/openai.ts
@@ -78,9 +78,21 @@ export const convertOpenAIResponseInputs = async (
   const input: OpenAI.Responses.ResponseInputItem[] = [];
   await Promise.all(
     messages.map(async (message) => {
+      // if message has encrypted content, add it as a separate reasoning item
+      if (message.encryptedContent) {
+        input.push({
+          encrypted_content: message.encryptedContent,
+          id: message.reasoningItemId || `encrypted-${Date.now()}`,
+          status: 'completed',
+          summary: [],
+          type: 'reasoning',
+        } as OpenAI.Responses.ResponseReasoningItem);
+      }
+
       // if message has reasoning, add it as a separate reasoning item
       if (message.reasoning?.content) {
         input.push({
+          id: message.reasoningItemId || `reasoning-${Date.now()}`,
           summary: [{ text: message.reasoning.content, type: 'summary_text' }],
           type: 'reasoning',
         } as OpenAI.Responses.ResponseReasoningItem);

--- a/packages/model-runtime/src/core/streams/openai/responsesStream.ts
+++ b/packages/model-runtime/src/core/streams/openai/responsesStream.ts
@@ -145,6 +145,14 @@ const transformOpenAIStream = (
       }
 
       case 'response.output_item.done': {
+        if (chunk.item.type === 'reasoning' && chunk.item.encrypted_content) {
+          return {
+            data: { content: chunk.item.encrypted_content, itemId: chunk.item.id },
+            id: chunk.item.id,
+            type: 'encrypted_content',
+          };
+        }
+
         if (streamContext.returnedCitationArray?.length) {
           return {
             data: { citations: streamContext.returnedCitationArray },

--- a/packages/model-runtime/src/core/streams/protocol.ts
+++ b/packages/model-runtime/src/core/streams/protocol.ts
@@ -96,6 +96,8 @@ export interface StreamProtocolChunk {
     | 'usage'
     // performance monitor
     | 'speed'
+    // encrypted content
+    | 'encrypted_content'
     // unknown data result
     | 'data';
 }
@@ -349,6 +351,14 @@ export function createCallbacksTransformer(cb: ChatStreamCallbacks | undefined) 
               mimeType: partData.mimeType,
               partType: partData.partType,
               thoughtSignature: partData.thoughtSignature,
+            });
+            break;
+          }
+
+          case 'encrypted_content': {
+            await callbacks.onEncryptedContent?.({
+              content: data.content,
+              itemId: data.itemId,
             });
             break;
           }

--- a/packages/model-runtime/src/types/chat.ts
+++ b/packages/model-runtime/src/types/chat.ts
@@ -46,11 +46,13 @@ export type UserMessageContentPart =
 
 export interface OpenAIChatMessage {
   content: string | UserMessageContentPart[];
+  encryptedContent?: string;
   name?: string;
   reasoning?: {
     content?: string;
     duration?: number;
   };
+  reasoningItemId?: string;
   role: LLMRoleType;
   tool_call_id?: string;
   tool_calls?: MessageToolCall[];
@@ -268,6 +270,11 @@ export interface ChatStreamCallbacks {
    * Used for models that return structured content with mixed text and images.
    */
   onContentPart?: (data: ContentPartData) => Promise<void> | void;
+  /**
+   * `onEncryptedContent`: Called when encrypted content is received from the model.
+   * Used for models that return encrypted content (e.g., OpenAI o-series models).
+   */
+  onEncryptedContent?: (data: { content: string; itemId?: string }) => Promise<void> | void;
   /** `onError`: Called when a stream error event is received from the provider. */
   onError?: (error: any) => Promise<void> | void;
   /**

--- a/packages/types/src/message/ui/chat.ts
+++ b/packages/types/src/message/ui/chat.ts
@@ -113,6 +113,10 @@ export interface UIChatMessage {
   compressedMessages?: UIChatMessage[];
   content: string;
   createdAt: number;
+  /**
+   * Encrypted content from OpenAI o-series models
+   */
+  encryptedContent?: string | null;
   error?: ChatMessageError | null;
   // Extended fields
   extra?: ChatMessageExtra;
@@ -168,6 +172,11 @@ export interface UIChatMessage {
   ragQueryId?: string | null;
   ragRawQuery?: string | null;
   reasoning?: ModelReasoning | null;
+  /**
+   * Reasoning item ID from OpenAI Response API
+   * Used for maintaining context connection in multi-turn conversations
+   */
+  reasoningItemId?: string | null;
   /**
    * message role type
    */

--- a/src/store/chat/agents/StreamingHandler.test.ts
+++ b/src/store/chat/agents/StreamingHandler.test.ts
@@ -5,6 +5,7 @@ import { type StreamingCallbacks, type StreamingContext } from './types/streamin
 
 const createMockCallbacks = (): StreamingCallbacks => ({
   onContentUpdate: vi.fn(),
+  onEncryptedContentUpdate: vi.fn(),
   onReasoningUpdate: vi.fn(),
   onToolCallsUpdate: vi.fn(),
   onGroundingUpdate: vi.fn(),

--- a/src/store/chat/agents/StreamingHandler.ts
+++ b/src/store/chat/agents/StreamingHandler.ts
@@ -103,6 +103,10 @@ export class StreamingHandler {
         this.handleReasoningChunk(chunk);
         break;
       }
+      case 'encrypted_content': {
+        this.handleEncryptedContentChunk(chunk);
+        break;
+      }
       case 'reasoning_part': {
         this.handleReasoningPartChunk(chunk);
         break;
@@ -223,6 +227,14 @@ export class StreamingHandler {
     this.thinkingContent += chunk.text;
 
     this.callbacks.onReasoningUpdate({ content: this.thinkingContent });
+  }
+
+  private handleEncryptedContentChunk(chunk: {
+    content: string;
+    itemId?: string;
+    type: 'encrypted_content';
+  }): void {
+    this.callbacks.onEncryptedContentUpdate(chunk.content, chunk.itemId);
   }
 
   private handleReasoningPartChunk(chunk: {

--- a/src/store/chat/agents/createAgentExecutors.ts
+++ b/src/store/chat/agents/createAgentExecutors.ts
@@ -270,6 +270,19 @@ export const createAgentExecutors = (context: {
               { operationId: context.operationId },
             );
           },
+          onEncryptedContentUpdate: (content, itemId) => {
+            internal_dispatchMessage(
+              {
+                id: assistantMessageId,
+                type: 'updateMessage',
+                value: {
+                  encryptedContent: content,
+                  ...(itemId && { reasoningItemId: itemId }),
+                },
+              },
+              { operationId: context.operationId },
+            );
+          },
           onReasoningUpdate: (reasoning) => {
             internal_dispatchMessage(
               {

--- a/src/store/chat/agents/types/streaming.ts
+++ b/src/store/chat/agents/types/streaming.ts
@@ -45,6 +45,8 @@ export interface StreamingCallbacks {
     reasoning?: ReasoningState,
     contentMetadata?: { isMultimodal: boolean; tempDisplayContent: string },
   ) => void;
+  /** Encrypted content update */
+  onEncryptedContentUpdate: (content: string, itemId?: string) => void;
   /** Search grounding update */
   onGroundingUpdate: (grounding: GroundingData) => void;
   /** Image list update */
@@ -107,6 +109,7 @@ export interface StreamingResult {
 export type StreamChunk =
   | { text: string; type: 'text' }
   | { text: string; type: 'reasoning' }
+  | { content: string; itemId?: string; type: 'encrypted_content' }
   | { content: string; mimeType?: string; partType: 'text' | 'image'; type: 'reasoning_part' }
   | { content: string; mimeType?: string; partType: 'text' | 'image'; type: 'content_part' }
   | {


### PR DESCRIPTION
Add full support for encrypted_content field in OpenAI Response API stream:
- Add encrypted_content type to StreamProtocolChunk
- Add onEncryptedContent callback to ChatStreamCallbacks
- Parse encrypted_content from response.output_item.done
- Add encrypted_content handling in createCallbacksTransformer
- Add encrypted_content to StreamChunk and StreamingCallbacks
- Implement handleEncryptedContentChunk in StreamingHandler
- Add encryptedContent and reasoningItemId to UIChatMessage and OpenAIChatMessage
- Convert encrypted_content to Response API format with original ID for context

#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## 由 Sourcery 提供的摘要

为 OpenAI Response API 的流式传输和消息处理在运行时、回调和 UI 消息类型中添加对加密内容的支持。

新特性：
- 支持从 OpenAI Response API 流式传输和处理 `encrypted_content` 分片（chunks），包括新的回调钩子。
- 扩展聊天消息类型，以存储加密内容及其关联的推理条目 ID，用于具备上下文的多轮对话。
- 在构建响应输入时，将已存储消息中的加密内容转换为 OpenAI Response API 的推理条目（reasoning items）。

测试：
- 扩展 `StreamingHandler` 测试，以覆盖新的加密内容流式回调路径。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for encrypted content in OpenAI Response API streaming and message handling across runtime, callbacks, and UI message types.

New Features:
- Support streaming and handling of encrypted_content chunks from OpenAI Response API, including new callback hooks.
- Extend chat message types to store encrypted content and associated reasoning item IDs for contextual multi-turn conversations.
- Convert encrypted content from stored messages into OpenAI Response API reasoning items when building response inputs.

Tests:
- Extend StreamingHandler tests to cover the new encrypted content streaming callback path.

</details>