### PR TITLE
✨ feat: add support for reasoning.encrypted_content in OpenAI Respons…

### DIFF
--- a/packages/database/src/models/message.ts
+++ b/packages/database/src/models/message.ts
@@ -1313,8 +1313,10 @@ export class MessageModel {
   update = async (
     id: string,
     { imageList, metadata, ...message }: Partial<UpdateMessageParams>,
-  ): Promise<{ success: boolean }> => {
+  ): Promise<{ success: boolean; messages?: UIChatMessage[] }> => {
     try {
+      let updatedMessages: UIChatMessage[] | undefined;
+
       await this.db.transaction(async (trx) => {
         // 1. insert message files
         if (imageList && imageList.length > 0) {
@@ -1339,12 +1341,23 @@ export class MessageModel {
           .update(messages)
           .set({ ...message, ...(mergedMetadata && { metadata: mergedMetadata }) })
           .where(and(eq(messages.id, id), eq(messages.userId, this.userId)));
+
+        // Fetch the updated message to return it
+        const [updated] = await trx
+          .select()
+          .from(messages)
+          .where(and(eq(messages.id, id), eq(messages.userId, this.userId)))
+          .limit(1);
+
+        if (updated.length > 0) {
+          updatedMessages = [updated[0] as any];
+        }
       });
 
-      return { success: true };
+      return { success: true, messages: updatedMessages };
     } catch (error) {
       console.error('Update message error:', error);
-      return { success: false };
+      return { success: false, messages: undefined };
     }
   };
 

--- a/packages/model-runtime/src/core/contextBuilders/openai.test.ts
+++ b/packages/model-runtime/src/core/contextBuilders/openai.test.ts
@@ -398,6 +398,65 @@ describe('convertOpenAIResponseInputs', () => {
     ]);
   });
 
+  it('should extract reasoning.encrypted_content into a separate reasoning item', async () => {
+    const messages: OpenAIChatMessage[] = [
+      { content: 'system prompts', role: 'system' },
+      { content: '你好', role: 'user' },
+      {
+        content: 'hello',
+        role: 'assistant',
+        reasoning: {
+          encrypted_content: 'encrypted reasoning content',
+        },
+      },
+      { content: '杭州天气如何', role: 'user' },
+    ];
+
+    const result = await convertOpenAIResponseInputs(messages);
+
+    expect(result).toEqual([
+      { content: 'system prompts', role: 'developer' },
+      { content: '你好', role: 'user' },
+      {
+        summary: [],
+        type: 'reasoning',
+        encrypted_content: 'encrypted reasoning content',
+      },
+      { content: 'hello', role: 'assistant' },
+      { content: '杭州天气如何', role: 'user' },
+    ]);
+  });
+
+  it('should extract both reasoning.content and reasoning.encrypted_content into a separate reasoning item', async () => {
+    const messages: OpenAIChatMessage[] = [
+      { content: 'system prompts', role: 'system' },
+      { content: '你好', role: 'user' },
+      {
+        content: 'hello',
+        role: 'assistant',
+        reasoning: {
+          content: 'reasoning content',
+          encrypted_content: 'encrypted reasoning content',
+        },
+      },
+      { content: '杭州天气如何', role: 'user' },
+    ];
+
+    const result = await convertOpenAIResponseInputs(messages);
+
+    expect(result).toEqual([
+      { content: 'system prompts', role: 'developer' },
+      { content: '你好', role: 'user' },
+      {
+        summary: [{ text: 'reasoning content', type: 'summary_text' }],
+        type: 'reasoning',
+        encrypted_content: 'encrypted reasoning content',
+      },
+      { content: 'hello', role: 'assistant' },
+      { content: '杭州天气如何', role: 'user' },
+    ]);
+  });
+
   it('should handle openai and claude mixed message', async () => {
     // See: https://github.com/lobehub/lobehub/pull/12017
     const messages: OpenAIChatMessage[] = [

--- a/packages/model-runtime/src/core/contextBuilders/openai.ts
+++ b/packages/model-runtime/src/core/contextBuilders/openai.ts
@@ -86,6 +86,14 @@ export const convertOpenAIResponseInputs = async (
         } as OpenAI.Responses.ResponseReasoningItem);
       }
 
+      // if message has encrypted reasoning, add it as a separate reasoning item
+      if (message.reasoning?.encrypted_content) {
+        input.push({
+          encrypted_content: message.reasoning.encrypted_content,
+          type: 'reasoning',
+        } as OpenAI.Responses.ResponseReasoningItem);
+      }
+
       // if message is assistant messages with tool calls , transform it to function type item
       if (message.role === 'assistant' && message.tool_calls && message.tool_calls?.length > 0) {
         message.tool_calls?.forEach((tool) => {

--- a/packages/model-runtime/src/core/streams/openai/__snapshots__/responsesStream.test.ts.snap
+++ b/packages/model-runtime/src/core/streams/openai/__snapshots__/responsesStream.test.ts.snap
@@ -392,6 +392,32 @@ exports[`OpenAIResponsesStream > should handle response.output_item.done with ci
 ]
 `;
 
+exports[`OpenAIResponsesStream > should handle response.output_item.done with encrypted_content 1`] = `
+[
+  "id: resp_encrypted
+",
+  "event: data
+",
+  "data: "in_progress"
+
+",
+  "id: resp_encrypted
+",
+  "event: data
+",
+  "data: {"id":"rs_test_id","type":"reasoning","status":"in_progress"}
+
+",
+  "id: rs_test_id
+",
+  "event: reasoning_encrypted
+",
+  "data: {"encrypted_content":"bvV88j99ILvgfHRTHCUSJtw+ISji6txJzPdZNbcSVuDk4OMG2Z9r5wOBBwjd3u3Hhm9XtpCWJO1YgTOlpgbn+g7DZX+pOagYYrCFUpQ19XkWz6Je8bHG9JcSDoGDqNgRbDbAUO8at6RCyqgPupJj5ArBDCt73fGQLTC4G3S0JMK9LsPiWz6GPj6qyzYoRzkj4R6bntRm74E4h8Y+z6u6B7+ixPSv8s1EFs8c+NUAB8TNKZZpXZquj2LXfx1xAie85Syl7qLqxLNtDG1dNBhBnHpYoE4gQzwyXqywf5pF2Q2imzPNzGQhurK+6gaNWgZbxRmjhdsW6TnzO5Kk6pzb5qpfgfcEScQeYHSj5GpD+yDUCNlhdbzhhWnEErH+wuBPpTG6UQhiC7m7yrJ7IY2E8K/BeUPlUvkhMaMwb4dA279pWMJdchNJ+TAxca+JVc80pXMG/PmrQUNJU9qdXRLbNmQbRadBNwV2qkPfgggL3q0yNd7Un9P+atmP3B9keBILif3ufsBDtVUobEniiyGV7YVDvQ/fQRVs7XDxJiOKkogjjQySyHgpjseO8iG5xtb9mrz6B3mDvv2aAuyDL6MHZRM7QDVPjUbgNMzDm5Sm3J7IhtzfR+3eMDws3qeTsxOt1KOslu983Btv1Wx37b5HJqX1pQU1dae/kOSJ7MifFd6wMkQtQBDgVoG3ka9wq5Vxq9Ki8bDOOMcwA2kUXhCcY3TZCXJfDWSKPTcCoNCYIv5LT2NFVdamiSfLIyeOjBNz459BfMvAoOZShFViQyc5YwjnReUQPQ8a18jcz8GoAK1O99e0h91oYxIgDV52EfS+IYrzqvJOEQbKQinB+LJwkPbBEp7ZtgAtiNBzm985hNgLfiBaVFWcRYwI3tNBCT1vkw2YI0NEEG0yOF29x9+u64XzqyP1CX1pU6sGXEFn3RPdfYibf6bt/Y1BRqBL5l0CrXWsgDw02SqIFta8OvJ7Iwmq40/4acE/Ew6eWO/z2MHkWgqSpwGNjn7MfeKkTi44foZjfNqN9QOFQt6VG2tY+biKZDo0h9DAftae8Q2Xs2UDvsBYOm7YEahVkput6/uKzxljpXlz269qHk6ckvdN9hKLbaTO3/IZPCCPQ5a/a/sWn/1VOJj72sDk+23RNjBf0FL6bJMXZI5aQdtxbF1zij9mWcP9nJ9FHhj53ytuf1NiKl5xU8ZsaoKmCAJcXUz1n2FZvyWlqvgPYiszc7R8Y5dF6QbW2mlKnXzVy6qRMHNeQqGhCEncyT5nPNSdK5QlUwLokAIg"}
+
+",
+]
+`;
+
 exports[`OpenAIResponsesStream > should handle response.output_item.done without citations 1`] = `
 [
   "id: resp_done_no_citation

--- a/packages/model-runtime/src/core/streams/openai/responsesStream.test.ts
+++ b/packages/model-runtime/src/core/streams/openai/responsesStream.test.ts
@@ -709,6 +709,45 @@ describe('OpenAIResponsesStream', () => {
     expect(chunks).toMatchSnapshot();
   });
 
+  it('should handle response.output_item.done with encrypted_content', async () => {
+    const mockOpenAIStream = createReadableStream([
+      {
+        type: 'response.created',
+        response: {
+          id: 'resp_encrypted',
+          status: 'in_progress',
+        },
+      },
+      {
+        type: 'response.output_item.added',
+        output_index: 0,
+        item: {
+          id: 'rs_test_id',
+          type: 'reasoning',
+          status: 'in_progress',
+        },
+      },
+      {
+        type: 'response.output_item.done',
+        output_index: 0,
+        item: {
+          id: 'rs_test_id',
+          type: 'reasoning',
+          status: 'completed',
+          encrypted_content:
+            'bvV88j99ILvgfHRTHCUSJtw+ISji6txJzPdZNbcSVuDk4OMG2Z9r5wOBBwjd3u3Hhm9XtpCWJO1YgTOlpgbn+g7DZX+pOagYYrCFUpQ19XkWz6Je8bHG9JcSDoGDqNgRbDbAUO8at6RCyqgPupJj5ArBDCt73fGQLTC4G3S0JMK9LsPiWz6GPj6qyzYoRzkj4R6bntRm74E4h8Y+z6u6B7+ixPSv8s1EFs8c+NUAB8TNKZZpXZquj2LXfx1xAie85Syl7qLqxLNtDG1dNBhBnHpYoE4gQzwyXqywf5pF2Q2imzPNzGQhurK+6gaNWgZbxRmjhdsW6TnzO5Kk6pzb5qpfgfcEScQeYHSj5GpD+yDUCNlhdbzhhWnEErH+wuBPpTG6UQhiC7m7yrJ7IY2E8K/BeUPlUvkhMaMwb4dA279pWMJdchNJ+TAxca+JVc80pXMG/PmrQUNJU9qdXRLbNmQbRadBNwV2qkPfgggL3q0yNd7Un9P+atmP3B9keBILif3ufsBDtVUobEniiyGV7YVDvQ/fQRVs7XDxJiOKkogjjQySyHgpjseO8iG5xtb9mrz6B3mDvv2aAuyDL6MHZRM7QDVPjUbgNMzDm5Sm3J7IhtzfR+3eMDws3qeTsxOt1KOslu983Btv1Wx37b5HJqX1pQU1dae/kOSJ7MifFd6wMkQtQBDgVoG3ka9wq5Vxq9Ki8bDOOMcwA2kUXhCcY3TZCXJfDWSKPTcCoNCYIv5LT2NFVdamiSfLIyeOjBNz459BfMvAoOZShFViQyc5YwjnReUQPQ8a18jcz8GoAK1O99e0h91oYxIgDV52EfS+IYrzqvJOEQbKQinB+LJwkPbBEp7ZtgAtiNBzm985hNgLfiBaVFWcRYwI3tNBCT1vkw2YI0NEEG0yOF29x9+u64XzqyP1CX1pU6sGXEFn3RPdfYibf6bt/Y1BRqBL5l0CrXWsgDw02SqIFta8OvJ7Iwmq40/4acE/Ew6eWO/z2MHkWgqSpwGNjn7MfeKkTi44foZjfNqN9QOFQt6VG2tY+biKZDo0h9DAftae8Q2Xs2UDvsBYOm7YEahVkput6/uKzxljpXlz269qHk6ckvdN9hKLbaTO3/IZPCCPQ5a/a/sWn/1VOJj72sDk+23RNjBf0FL6bJMXZI5aQdtxbF1zij9mWcP9nJ9FHhj53ytuf1NiKl5xU8ZsaoKmCAJcXUz1n2FZvyWlqvgPYiszc7R8Y5dF6QbW2mlKnXzVy6qRMHNeQqGhCEncyT5nPNSdK5QlUwLokAIg',
+        },
+      },
+    ]);
+
+    const protocolStream = OpenAIResponsesStream(mockOpenAIStream);
+    const chunks = await readStreamChunk(protocolStream);
+
+    expect(chunks).toMatchSnapshot();
+    expect(chunks.some((c) => c.includes('event: reasoning_encrypted'))).toBe(true);
+    expect(chunks.some((c) => c.includes('encrypted_content'))).toBe(true);
+  });
+
   it('should handle response.completed with usage', async () => {
     const mockOpenAIStream = createReadableStream([
       {

--- a/packages/model-runtime/src/core/streams/openai/responsesStream.ts
+++ b/packages/model-runtime/src/core/streams/openai/responsesStream.ts
@@ -145,6 +145,19 @@ const transformOpenAIStream = (
       }
 
       case 'response.output_item.done': {
+        if (
+          chunk.item.type === 'reasoning' &&
+          'encrypted_content' in chunk.item &&
+          chunk.item.encrypted_content
+        ) {
+          streamContext.encrypted_content = chunk.item.encrypted_content;
+          return {
+            data: { encrypted_content: chunk.item.encrypted_content },
+            id: chunk.item.id,
+            type: 'reasoning_encrypted',
+          };
+        }
+
         if (streamContext.returnedCitationArray?.length) {
           return {
             data: { citations: streamContext.returnedCitationArray },

--- a/packages/model-runtime/src/core/streams/protocol.ts
+++ b/packages/model-runtime/src/core/streams/protocol.ts
@@ -65,6 +65,10 @@ export interface StreamContext {
    */
   tools?: Record<number, { id: string; index: number; name: string }>;
   usage?: ModelUsage;
+  /**
+   * Encrypted reasoning content from providers (e.g., xAI Grok models)
+   */
+  encrypted_content?: string;
 }
 
 export interface StreamProtocolChunk {
@@ -88,6 +92,8 @@ export interface StreamProtocolChunk {
     | 'content_part'
     // Search or Grounding
     | 'grounding'
+    // encrypted reasoning content (e.g., xAI Grok)
+    | 'reasoning_encrypted'
     // stop signal
     | 'stop'
     // Error

--- a/packages/model-runtime/src/types/chat.ts
+++ b/packages/model-runtime/src/types/chat.ts
@@ -50,6 +50,10 @@ export interface OpenAIChatMessage {
   reasoning?: {
     content?: string;
     duration?: number;
+    /**
+     * Encrypted reasoning content from providers (e.g., xAI Grok models)
+     */
+    encrypted_content?: string;
   };
   role: LLMRoleType;
   tool_call_id?: string;

--- a/packages/types/src/message/common/base.ts
+++ b/packages/types/src/message/common/base.ts
@@ -55,6 +55,11 @@ export interface ModelReasoning {
   isMultimodal?: boolean;
   signature?: string;
   tempDisplayContent?: MessageContentPart[];
+  /**
+   * Encrypted reasoning content from providers (e.g., xAI Grok models)
+   * Base64-encoded encrypted reasoning data
+   */
+  encrypted_content?: string;
 }
 
 export const ModelReasoningSchema = z.object({
@@ -62,4 +67,5 @@ export const ModelReasoningSchema = z.object({
   duration: z.number().optional(),
   isMultimodal: z.boolean().optional(),
   signature: z.string().optional(),
+  encrypted_content: z.string().optional(),
 });

--- a/src/services/message/index.ts
+++ b/src/services/message/index.ts
@@ -104,11 +104,13 @@ export class MessageService {
     value: Partial<UpdateMessageParams>,
     ctx?: MessageQueryContext,
   ): Promise<UpdateMessageResult> => {
-    return lambdaClient.message.update.mutate({
+    const result = await lambdaClient.message.update.mutate({
       ...ctx,
       id,
       value,
     });
+
+    return { ...result, messages: result.messages || undefined };
   };
 
   updateMessageTranslate = async (id: string, translate: Partial<ChatTranslate> | false) => {

--- a/src/store/chat/agents/StreamingHandler.ts
+++ b/src/store/chat/agents/StreamingHandler.ts
@@ -504,6 +504,13 @@ export class StreamingHandler {
     // Get encrypted_content from either stream or finishData
     const encryptedContent = this.encryptedContent || finishData.reasoning?.encrypted_content;
 
+    log(
+      '[buildFinalResult] messageId=%s, encryptedContent=%s, thinkingContent=%s',
+      this.context.messageId,
+      encryptedContent ? 'present' : 'missing',
+      this.thinkingContent ? 'present' : 'missing',
+    );
+
     let finalReasoning: ReasoningState | undefined;
     if (hasReasoningImages) {
       finalReasoning = {

--- a/src/store/chat/agents/StreamingHandler.ts
+++ b/src/store/chat/agents/StreamingHandler.ts
@@ -53,6 +53,7 @@ export class StreamingHandler {
   private thinkingDuration?: number;
   private reasoningOperationId?: string;
   private reasoningParts: MessageContentPart[] = [];
+  private encryptedContent?: string;
 
   // ========== Multimodal state ==========
   private contentParts: MessageContentPart[] = [];
@@ -101,6 +102,10 @@ export class StreamingHandler {
       }
       case 'reasoning': {
         this.handleReasoningChunk(chunk);
+        break;
+      }
+      case 'reasoning_encrypted': {
+        this.handleReasoningEncryptedChunk(chunk);
         break;
       }
       case 'reasoning_part': {
@@ -223,6 +228,18 @@ export class StreamingHandler {
     this.thinkingContent += chunk.text;
 
     this.callbacks.onReasoningUpdate({ content: this.thinkingContent });
+  }
+
+  private handleReasoningEncryptedChunk(chunk: {
+    encrypted_content: string;
+    type: 'reasoning_encrypted';
+  }): void {
+    this.encryptedContent = chunk.encrypted_content;
+
+    this.callbacks.onReasoningUpdate({
+      content: this.thinkingContent,
+      encrypted_content: this.encryptedContent,
+    });
   }
 
   private handleReasoningPartChunk(chunk: {
@@ -484,6 +501,9 @@ export class StreamingHandler {
     // Get signature from finishData.reasoning (provided by backend in onFinish)
     const reasoningSignature = finishData.reasoning?.signature;
 
+    // Get encrypted_content from either stream or finishData
+    const encryptedContent = this.encryptedContent || finishData.reasoning?.encrypted_content;
+
     let finalReasoning: ReasoningState | undefined;
     if (hasReasoningImages) {
       finalReasoning = {
@@ -491,12 +511,14 @@ export class StreamingHandler {
         duration: finalDuration,
         isMultimodal: true,
         signature: reasoningSignature,
+        encrypted_content: encryptedContent,
       };
-    } else if (this.thinkingContent) {
+    } else if (this.thinkingContent || encryptedContent) {
       finalReasoning = {
         content: this.thinkingContent,
         duration: finalDuration,
         signature: reasoningSignature,
+        encrypted_content: encryptedContent,
       };
     } else if (finishData.reasoning?.content) {
       finalReasoning = {

--- a/src/store/chat/agents/createAgentExecutors.ts
+++ b/src/store/chat/agents/createAgentExecutors.ts
@@ -430,6 +430,12 @@ export const createAgentExecutors = (context: {
           finalUsage = result.usage;
           finalToolCalls = result.toolCalls;
 
+          log(
+            '[optimisticUpdateMessageContent] messageId=%s, reasoning=%o',
+            assistantMessageId,
+            result.metadata.reasoning,
+          );
+
           await optimisticUpdateMessageContent(
             assistantMessageId,
             result.content,

--- a/src/store/chat/agents/types/streaming.ts
+++ b/src/store/chat/agents/types/streaming.ts
@@ -28,6 +28,10 @@ export interface ReasoningState {
   isMultimodal?: boolean;
   signature?: string;
   tempDisplayContent?: MessageContentPart[];
+  /**
+   * Encrypted reasoning content from providers (e.g., xAI Grok models)
+   */
+  encrypted_content?: string;
 }
 
 /**
@@ -71,7 +75,7 @@ export interface StreamingCallbacks {
 export interface FinishData {
   grounding?: GroundingData;
   observationId?: string | null;
-  reasoning?: { content?: string; signature?: string };
+  reasoning?: { content?: string; signature?: string; encrypted_content?: string };
   speed?: ModelPerformance;
   toolCalls?: MessageToolCall[];
   traceId?: string | null;
@@ -107,6 +111,7 @@ export interface StreamingResult {
 export type StreamChunk =
   | { text: string; type: 'text' }
   | { text: string; type: 'reasoning' }
+  | { encrypted_content: string; type: 'reasoning_encrypted' }
   | { content: string; mimeType?: string; partType: 'text' | 'image'; type: 'reasoning_part' }
   | { content: string; mimeType?: string; partType: 'text' | 'image'; type: 'content_part' }
   | {


### PR DESCRIPTION
…e API

- Add encrypted_content field to ModelReasoning type and schema
- Capture encrypted_content from reasoning items in responsesStream
- Add reasoning_encrypted stream protocol type
- Update StreamingHandler to process encrypted_content
- Update OpenAI factory to include encrypted_content in message payload
- Add test cases for encrypted_content handling

This enables xAI Grok models to properly handle encrypted reasoning content in multi-turn conversations, which is passed back to the model but not displayed to users.

#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

为基于 OpenAI 的流式处理和消息处理添加对加密推理内容的支持，使得 xAI Grok 等提供方可以在多轮对话中往返传递隐藏的推理数据。

New Features:
- 从 OpenAI 响应中捕获加密推理内容，并通过新的 `reasoning_encrypted` 流块类型对其进行暴露。
- 扩展推理状态和消息类型，以存储 `encrypted_content`，供后续的聊天处理使用。

Enhancements:
- 更新流式处理程序和上下文构建器，在可能的情况下，与可见推理文本一起持久化和传播加密推理内容。

Tests:
- 添加单元测试和快照，用于验证在 OpenAI 消息和响应流中对加密推理内容的提取、流式传输和处理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for encrypted reasoning content in OpenAI-based streaming and message handling so providers like xAI Grok can round-trip hidden reasoning data across multi-turn conversations.

New Features:
- Capture encrypted reasoning content from OpenAI responses and expose it via a new reasoning_encrypted stream chunk type.
- Extend reasoning state and message types to store encrypted_content for use in downstream chat handling.

Enhancements:
- Update streaming handler and context builders to persist and propagate encrypted reasoning content alongside visible reasoning text where available.

Tests:
- Add unit tests and snapshots to verify extraction, streaming, and handling of encrypted reasoning content in OpenAI messages and response streams.

</details>