### PR TITLE
💄 style: add multimodal support for LongCat

### DIFF
--- a/packages/model-bank/src/aiModels/longcat.ts
+++ b/packages/model-bank/src/aiModels/longcat.ts
@@ -4,6 +4,27 @@ const longcatModels: AIChatModelCard[] = [
   {
     abilities: {
       functionCall: true,
+      video: true,
+      vision: true,
+    },
+    contextWindowTokens: 8192,
+    description:
+      'LongCat-Flash-Omni-2603 has been officially released. As an upgraded version of LongCat-Flash-Omni, it is an end-to-end Omni interaction model with higher human-like response quality and stronger full-modal perception capabilities. It can be used for free in LongCat Chat, or accessed via API by specifying `model=LongCat-Flash-Omni-2603`. Compared with the LongCat-Flash-Omni model, the key features of LongCat-Flash-Omni-2603 include: Deeper semantic alignment and personalized style adaptation, providing a more natural and smooth conversational experience. Comprehensive improvements in multimodal task accuracy, including vision, speech, and text. Significantly enhanced performance in problem-solving, emotional understanding, and everyday entertainment scenarios. Native voice Function Call support, enabling direct parsing of audio commands with near-zero-latency real-time interaction.',
+    displayName: 'LongCat-Flash-Omni-2603',
+    enabled: true,
+    id: 'LongCat-Flash-Omni-2603',
+    pricing: {
+      units: [
+        { name: 'textInput', rate: 0, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 0, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    releasedAt: '2026-03-11',
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
     },
     contextWindowTokens: 327_680,
     description:
@@ -29,7 +50,6 @@ const longcatModels: AIChatModelCard[] = [
     description:
       'The LongCat-Flash-Thinking-2601 model has been officially released. As an upgraded reasoning model built on a Mixture-of-Experts (MoE) architecture, it features a total of 560 billion parameters. While maintaining strong competitiveness across traditional reasoning benchmarks, it systematically enhances Agent-level reasoning capabilities through large-scale multi-environment reinforcement learning. Compared to the LongCat-Flash-Thinking model, the key upgrades are as follows: Extreme Robustness in Noisy Environments: Through systematic curriculum-style training targeting noise and uncertainty in real-world settings, the model demonstrates outstanding performance in Agent tool invocation, Agent-based search, and tool-integrated reasoning, with significantly improved generalization. Powerful Agent Capabilities: By constructing a tightly coupled dependency graph encompassing more than 60 tools, and scaling training through multi-environment expansion and large-scale exploratory learning, the model markedly improves its ability to generalize to complex and out-of-distribution real-world scenarios. Advanced Deep Thinking Mode: It expands the breadth of reasoning via parallel inference and deepens analytical capability through recursive feedback-driven summarization and abstraction mechanisms, effectively addressing highly challenging problems.',
     displayName: 'LongCat-Flash-Thinking-2601',
-    enabled: true,
     id: 'LongCat-Flash-Thinking-2601',
     pricing: {
       units: [
@@ -49,6 +69,7 @@ const longcatModels: AIChatModelCard[] = [
     description:
       'LongCat-Flash-Thinking has been officially released and open-sourced simultaneously. It is a deep reasoning model that can be used for free conversations within LongCat Chat, or accessed via API by specifying model=LongCat-Flash-Thinking.',
     displayName: 'LongCat-Flash-Thinking',
+    enabled: true,
     id: 'LongCat-Flash-Thinking',
     pricing: {
       units: [
@@ -56,7 +77,7 @@ const longcatModels: AIChatModelCard[] = [
         { name: 'textOutput', rate: 0, strategy: 'fixed', unit: 'millionTokens' },
       ],
     },
-    releasedAt: '2025-09-22',
+    releasedAt: '2026-03-12',
     type: 'chat',
   },
   {

--- a/packages/model-runtime/src/core/contextBuilders/longcat.test.ts
+++ b/packages/model-runtime/src/core/contextBuilders/longcat.test.ts
@@ -5,16 +5,16 @@ import { transformLongCatMessage } from './longcat';
 
 describe('transformLongCatMessage', () => {
   describe('string content', () => {
-    it('should return string content unchanged', () => {
+    it('should convert string content to text array format', () => {
       const content = 'Hello, world!';
       const result = transformLongCatMessage(content);
-      expect(result).toBe('Hello, world!');
+      expect(result).toEqual([{ type: 'text', text: 'Hello, world!' }]);
     });
 
-    it('should return empty string unchanged', () => {
+    it('should convert empty string to text array format', () => {
       const content = '';
       const result = transformLongCatMessage(content);
-      expect(result).toBe('');
+      expect(result).toEqual([{ type: 'text', text: '' }]);
     });
   });
 
@@ -43,7 +43,7 @@ describe('transformLongCatMessage', () => {
         {
           type: 'input_image',
           input_image: {
-            data: 'https://example.com/image.jpg',
+            data: ['https://example.com/image.jpg'],
             type: 'url',
           },
         },
@@ -62,7 +62,7 @@ describe('transformLongCatMessage', () => {
         {
           type: 'input_image',
           input_image: {
-            data: 'data:image/jpeg;base64,abc123',
+            data: ['data:image/jpeg;base64,abc123'],
             type: 'base64',
           },
         },
@@ -81,7 +81,7 @@ describe('transformLongCatMessage', () => {
         {
           type: 'input_image',
           input_image: {
-            data: 'data:image/png;base64,xyz789',
+            data: ['data:image/png;base64,xyz789'],
             type: 'base64',
           },
         },
@@ -163,7 +163,7 @@ describe('transformLongCatMessage', () => {
         {
           type: 'input_image',
           input_image: {
-            data: 'https://example.com/image.png',
+            data: ['https://example.com/image.png'],
             type: 'url',
           },
         },
@@ -197,21 +197,21 @@ describe('transformLongCatMessage', () => {
         {
           type: 'input_image',
           input_image: {
-            data: 'https://example.com/image1.jpg',
+            data: ['https://example.com/image1.jpg'],
             type: 'url',
           },
         },
         {
           type: 'input_image',
           input_image: {
-            data: 'https://example.com/image2.jpg',
+            data: ['https://example.com/image2.jpg'],
             type: 'url',
           },
         },
         {
           type: 'input_image',
           input_image: {
-            data: 'data:image/jpeg;base64,base64img',
+            data: ['data:image/jpeg;base64,base64img'],
             type: 'base64',
           },
         },
@@ -305,7 +305,7 @@ describe('transformLongCatMessage', () => {
         {
           type: 'input_image',
           input_image: {
-            data: 'https://example.com/photo.jpeg',
+            data: ['https://example.com/photo.jpeg'],
             type: 'url',
           },
         },
@@ -351,7 +351,7 @@ describe('transformLongCatMessage', () => {
         {
           type: 'input_image',
           input_image: {
-            data: 'data:image/png;base64,img123',
+            data: ['data:image/png;base64,img123'],
             type: 'base64',
           },
         },
@@ -390,7 +390,7 @@ describe('transformLongCatMessage', () => {
         {
           type: 'input_image',
           input_image: {
-            data: 'https://cdn.example.com/img1.jpg',
+            data: ['https://cdn.example.com/img1.jpg'],
             type: 'url',
           },
         },
@@ -406,7 +406,7 @@ describe('transformLongCatMessage', () => {
         {
           type: 'input_image',
           input_image: {
-            data: 'data:image/webp;base64,webpdata',
+            data: ['data:image/webp;base64,webpdata'],
             type: 'base64',
           },
         },
@@ -460,7 +460,7 @@ describe('transformLongCatMessage', () => {
         {
           type: 'input_image',
           input_image: {
-            data: 'data:application/octet-stream;base64,rawdata',
+            data: ['data:application/octet-stream;base64,rawdata'],
             type: 'base64',
           },
         },

--- a/packages/model-runtime/src/core/contextBuilders/longcat.test.ts
+++ b/packages/model-runtime/src/core/contextBuilders/longcat.test.ts
@@ -1,0 +1,482 @@
+import { describe, expect, it } from 'vitest';
+
+import type { OpenAIChatMessage } from '../../types';
+import { transformLongCatMessage } from './longcat';
+
+describe('transformLongCatMessage', () => {
+  describe('string content', () => {
+    it('should return string content unchanged', () => {
+      const content = 'Hello, world!';
+      const result = transformLongCatMessage(content);
+      expect(result).toBe('Hello, world!');
+    });
+
+    it('should return empty string unchanged', () => {
+      const content = '';
+      const result = transformLongCatMessage(content);
+      expect(result).toBe('');
+    });
+  });
+
+  describe('array content', () => {
+    it('should return text content unchanged', () => {
+      const content = [
+        { type: 'text', text: 'Hello' },
+        { type: 'text', text: 'World' },
+      ] as any;
+      const result = transformLongCatMessage(content);
+      expect(result).toEqual([
+        { type: 'text', text: 'Hello' },
+        { type: 'text', text: 'World' },
+      ]);
+    });
+
+    it('should transform image_url with URL to input_image format', () => {
+      const content = [
+        {
+          type: 'image_url',
+          image_url: { url: 'https://example.com/image.jpg' },
+        },
+      ] as any;
+      const result = transformLongCatMessage(content);
+      expect(result).toEqual([
+        {
+          type: 'input_image',
+          input_image: {
+            data: 'https://example.com/image.jpg',
+            type: 'url',
+          },
+        },
+      ]);
+    });
+
+    it('should transform image_url with base64 to input_image format', () => {
+      const content = [
+        {
+          type: 'image_url',
+          image_url: { url: 'data:image/jpeg;base64,abc123' },
+        },
+      ] as any;
+      const result = transformLongCatMessage(content);
+      expect(result).toEqual([
+        {
+          type: 'input_image',
+          input_image: {
+            data: 'data:image/jpeg;base64,abc123',
+            type: 'base64',
+          },
+        },
+      ]);
+    });
+
+    it('should transform image_url with PNG base64 to input_image format', () => {
+      const content = [
+        {
+          type: 'image_url',
+          image_url: { url: 'data:image/png;base64,xyz789' },
+        },
+      ] as any;
+      const result = transformLongCatMessage(content);
+      expect(result).toEqual([
+        {
+          type: 'input_image',
+          input_image: {
+            data: 'data:image/png;base64,xyz789',
+            type: 'base64',
+          },
+        },
+      ]);
+    });
+
+    it('should transform video_url with URL to input_video format', () => {
+      const content = [
+        {
+          type: 'video_url',
+          video_url: { url: 'https://example.com/video.mp4' },
+        },
+      ] as any;
+      const result = transformLongCatMessage(content);
+      expect(result).toEqual([
+        {
+          type: 'input_video',
+          input_video: {
+            data: 'https://example.com/video.mp4',
+            type: 'url',
+          },
+        },
+      ]);
+    });
+
+    it('should transform video_url with base64 to input_video format', () => {
+      const content = [
+        {
+          type: 'video_url',
+          video_url: { url: 'data:video/mp4;base64,video123' },
+        },
+      ] as any;
+      const result = transformLongCatMessage(content);
+      expect(result).toEqual([
+        {
+          type: 'input_video',
+          input_video: {
+            data: 'data:video/mp4;base64,video123',
+            type: 'base64',
+          },
+        },
+      ]);
+    });
+
+    it('should transform video_url with MOV format to input_video format', () => {
+      const content = [
+        {
+          type: 'video_url',
+          video_url: { url: 'data:video/quicktime;base64,mov123' },
+        },
+      ] as any;
+      const result = transformLongCatMessage(content);
+      expect(result).toEqual([
+        {
+          type: 'input_video',
+          input_video: {
+            data: 'data:video/quicktime;base64,mov123',
+            type: 'base64',
+          },
+        },
+      ]);
+    });
+
+    it('should handle mixed content with text, image, and video', () => {
+      const content = [
+        { type: 'text', text: 'Check out this image and video' },
+        {
+          type: 'image_url',
+          image_url: { url: 'https://example.com/image.png' },
+        },
+        {
+          type: 'video_url',
+          video_url: { url: 'https://example.com/video.mp4' },
+        },
+      ] as any;
+      const result = transformLongCatMessage(content);
+      expect(result).toEqual([
+        { type: 'text', text: 'Check out this image and video' },
+        {
+          type: 'input_image',
+          input_image: {
+            data: 'https://example.com/image.png',
+            type: 'url',
+          },
+        },
+        {
+          type: 'input_video',
+          input_video: {
+            data: 'https://example.com/video.mp4',
+            type: 'url',
+          },
+        },
+      ]);
+    });
+
+    it('should handle multiple images in sequence', () => {
+      const content = [
+        {
+          type: 'image_url',
+          image_url: { url: 'https://example.com/image1.jpg' },
+        },
+        {
+          type: 'image_url',
+          image_url: { url: 'https://example.com/image2.jpg' },
+        },
+        {
+          type: 'image_url',
+          image_url: { url: 'data:image/jpeg;base64,base64img' },
+        },
+      ] as any;
+      const result = transformLongCatMessage(content);
+      expect(result).toEqual([
+        {
+          type: 'input_image',
+          input_image: {
+            data: 'https://example.com/image1.jpg',
+            type: 'url',
+          },
+        },
+        {
+          type: 'input_image',
+          input_image: {
+            data: 'https://example.com/image2.jpg',
+            type: 'url',
+          },
+        },
+        {
+          type: 'input_image',
+          input_image: {
+            data: 'data:image/jpeg;base64,base64img',
+            type: 'base64',
+          },
+        },
+      ]);
+    });
+
+    it('should handle multiple videos in sequence', () => {
+      const content = [
+        {
+          type: 'video_url',
+          video_url: { url: 'https://example.com/video1.mp4' },
+        },
+        {
+          type: 'video_url',
+          video_url: { url: 'data:video/mp4;base64,video1' },
+        },
+        {
+          type: 'video_url',
+          video_url: { url: 'https://example.com/video2.avi' },
+        },
+      ] as any;
+      const result = transformLongCatMessage(content);
+      expect(result).toEqual([
+        {
+          type: 'input_video',
+          input_video: {
+            data: 'https://example.com/video1.mp4',
+            type: 'url',
+          },
+        },
+        {
+          type: 'input_video',
+          input_video: {
+            data: 'data:video/mp4;base64,video1',
+            type: 'base64',
+          },
+        },
+        {
+          type: 'input_video',
+          input_video: {
+            data: 'https://example.com/video2.avi',
+            type: 'url',
+          },
+        },
+      ]);
+    });
+
+    it('should handle empty array content', () => {
+      const content: any[] = [];
+      const result = transformLongCatMessage(content);
+      expect(result).toEqual([]);
+    });
+
+    it('should preserve unknown content types', () => {
+      const content = [
+        { type: 'text', text: 'Hello' },
+        { type: 'unknown_type', data: 'something' },
+      ] as any;
+      const result = transformLongCatMessage(content);
+      expect(result).toEqual([
+        { type: 'text', text: 'Hello' },
+        { type: 'unknown_type', data: 'something' },
+      ]);
+    });
+
+    it('should handle thinking content type (for Claude compatibility)', () => {
+      const content = [
+        { type: 'thinking', thinking: 'Let me think...', signature: 'sig123' },
+        { type: 'text', text: 'Response' },
+      ] as any;
+      const result = transformLongCatMessage(content);
+      expect(result).toEqual([
+        { type: 'thinking', thinking: 'Let me think...', signature: 'sig123' },
+        { type: 'text', text: 'Response' },
+      ]);
+    });
+  });
+
+  describe('integration scenarios', () => {
+    it('should handle typical user message with image attachment', () => {
+      const content: OpenAIChatMessage['content'] = [
+        { type: 'text', text: 'What is in this image?' },
+        {
+          type: 'image_url',
+          image_url: { url: 'https://example.com/photo.jpeg' },
+        },
+      ];
+      const result = transformLongCatMessage(content);
+      expect(result).toEqual([
+        { type: 'text', text: 'What is in this image?' },
+        {
+          type: 'input_image',
+          input_image: {
+            data: 'https://example.com/photo.jpeg',
+            type: 'url',
+          },
+        },
+      ]);
+    });
+
+    it('should handle typical user message with video attachment', () => {
+      const content: OpenAIChatMessage['content'] = [
+        { type: 'text', text: 'Analyze this video' },
+        {
+          type: 'video_url',
+          video_url: { url: 'data:video/mp4;base64,videodata' },
+        },
+      ];
+      const result = transformLongCatMessage(content);
+      expect(result).toEqual([
+        { type: 'text', text: 'Analyze this video' },
+        {
+          type: 'input_video',
+          input_video: {
+            data: 'data:video/mp4;base64,videodata',
+            type: 'base64',
+          },
+        },
+      ]);
+    });
+
+    it('should handle multimodal message with image and video', () => {
+      const content: OpenAIChatMessage['content'] = [
+        { type: 'text', text: 'Compare these' },
+        {
+          type: 'image_url',
+          image_url: { url: 'data:image/png;base64,img123' },
+        },
+        {
+          type: 'video_url',
+          video_url: { url: 'https://example.com/clip.mov' },
+        },
+      ];
+      const result = transformLongCatMessage(content);
+      expect(result).toEqual([
+        { type: 'text', text: 'Compare these' },
+        {
+          type: 'input_image',
+          input_image: {
+            data: 'data:image/png;base64,img123',
+            type: 'base64',
+          },
+        },
+        {
+          type: 'input_video',
+          input_video: {
+            data: 'https://example.com/clip.mov',
+            type: 'url',
+          },
+        },
+      ]);
+    });
+
+    it('should handle complex conversation with multiple modalities', () => {
+      const content: OpenAIChatMessage['content'] = [
+        { type: 'text', text: 'First, look at this image:' },
+        {
+          type: 'image_url',
+          image_url: { url: 'https://cdn.example.com/img1.jpg' },
+        },
+        { type: 'text', text: 'Now watch this video:' },
+        {
+          type: 'video_url',
+          video_url: { url: 'https://cdn.example.com/vid1.mp4' },
+        },
+        { type: 'text', text: 'And this base64 image:' },
+        {
+          type: 'image_url',
+          image_url: { url: 'data:image/webp;base64,webpdata' },
+        },
+        { type: 'text', text: 'What do you think?' },
+      ];
+      const result = transformLongCatMessage(content);
+      expect(result).toEqual([
+        { type: 'text', text: 'First, look at this image:' },
+        {
+          type: 'input_image',
+          input_image: {
+            data: 'https://cdn.example.com/img1.jpg',
+            type: 'url',
+          },
+        },
+        { type: 'text', text: 'Now watch this video:' },
+        {
+          type: 'input_video',
+          input_video: {
+            data: 'https://cdn.example.com/vid1.mp4',
+            type: 'url',
+          },
+        },
+        { type: 'text', text: 'And this base64 image:' },
+        {
+          type: 'input_image',
+          input_image: {
+            data: 'data:image/webp;base64,webpdata',
+            type: 'base64',
+          },
+        },
+        { type: 'text', text: 'What do you think?' },
+      ]);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle image_url with undefined video_url field', () => {
+      const content = [
+        {
+          type: 'image_url',
+          image_url: { url: 'https://example.com/test.png' },
+        },
+      ] as any;
+      const result = transformLongCatMessage(content);
+      expect(result[0]).toHaveProperty('type', 'input_image');
+      expect(result[0]).toHaveProperty('input_image');
+      expect((result[0] as any).input_image.type).toBe('url');
+    });
+
+    it('should handle video_url with missing url gracefully', () => {
+      const content = [
+        {
+          type: 'video_url',
+          video_url: {} as any,
+        },
+      ] as any;
+      const result = transformLongCatMessage(content);
+      expect(result).toEqual([
+        {
+          type: 'input_video',
+          input_video: {
+            data: undefined,
+            type: 'url',
+          },
+        },
+      ]);
+    });
+
+    it('should handle data URLs without explicit media type', () => {
+      const content = [
+        {
+          type: 'image_url',
+          image_url: { url: 'data:application/octet-stream;base64,rawdata' },
+        },
+      ] as any;
+      const result = transformLongCatMessage(content);
+      expect(result).toEqual([
+        {
+          type: 'input_image',
+          input_image: {
+            data: 'data:application/octet-stream;base64,rawdata',
+            type: 'base64',
+          },
+        },
+      ]);
+    });
+
+    it('should preserve additional properties on content parts', () => {
+      const content = [
+        {
+          type: 'text',
+          text: 'Hello',
+          customProp: 'value',
+        } as any,
+      ];
+      const result = transformLongCatMessage(content);
+      expect(result[0]).toHaveProperty('customProp', 'value');
+    });
+  });
+});

--- a/packages/model-runtime/src/core/contextBuilders/longcat.ts
+++ b/packages/model-runtime/src/core/contextBuilders/longcat.ts
@@ -1,16 +1,20 @@
 import type { OpenAIChatMessage } from '../../types';
 
 /**
- * Transform generic OpenAI format to LongCat specific format
- * LongCat requires nested object structure for images/videos:
- * - image_url: { url: string } -> input_image: { data: string, type: 'url' | 'base64' }
- * - video_url: { url: string } -> input_video: { data: string, type: 'url' | 'base64' }
+ * Transform generic OpenAI format to LongCat Omni specific format
+ * LongCat Omni models require:
+ * 1. All content must be array format: [{type: "text", text: "..."}]
+ * 2. image_url: { url: string } -> input_image: { data: string[], type: 'url' | 'base64' }
+ * 3. video_url: { url: string } -> input_video: { data: string, type: 'url' | 'base64' }
+ *
+ * Note: Only image data is an array, video data is a single string
  */
 export const transformLongCatMessage = (
   content: string | OpenAIChatMessage['content'],
 ): OpenAIChatMessage['content'] => {
+  // Convert string content to text array format
   if (typeof content === 'string') {
-    return content;
+    return [{ type: 'text', text: content }];
   }
 
   return content.map((part) => {
@@ -20,7 +24,7 @@ export const transformLongCatMessage = (
 
       return {
         input_image: {
-          data: url,
+          data: [url],
           type: isBase64 ? 'base64' : 'url',
         },
         type: 'input_image',
@@ -40,6 +44,7 @@ export const transformLongCatMessage = (
       } as any;
     }
 
+    // Preserve text and other content types as is
     return part;
   });
 };

--- a/packages/model-runtime/src/core/contextBuilders/longcat.ts
+++ b/packages/model-runtime/src/core/contextBuilders/longcat.ts
@@ -1,0 +1,45 @@
+import type { OpenAIChatMessage } from '../../types';
+
+/**
+ * Transform generic OpenAI format to LongCat specific format
+ * LongCat requires nested object structure for images/videos:
+ * - image_url: { url: string } -> input_image: { data: string, type: 'url' | 'base64' }
+ * - video_url: { url: string } -> input_video: { data: string, type: 'url' | 'base64' }
+ */
+export const transformLongCatMessage = (
+  content: string | OpenAIChatMessage['content'],
+): OpenAIChatMessage['content'] => {
+  if (typeof content === 'string') {
+    return content;
+  }
+
+  return content.map((part) => {
+    if (part.type === 'image_url') {
+      const url = part.image_url.url;
+      const isBase64 = url.startsWith('data:');
+
+      return {
+        input_image: {
+          data: url,
+          type: isBase64 ? 'base64' : 'url',
+        },
+        type: 'input_image',
+      } as any;
+    }
+
+    if (part.type === 'video_url') {
+      const url = (part as any).video_url?.url;
+      const isBase64 = url?.startsWith('data:');
+
+      return {
+        input_video: {
+          data: url,
+          type: isBase64 ? 'base64' : 'url',
+        },
+        type: 'input_video',
+      } as any;
+    }
+
+    return part;
+  });
+};

--- a/packages/model-runtime/src/providers/longcat/index.ts
+++ b/packages/model-runtime/src/providers/longcat/index.ts
@@ -9,15 +9,16 @@ export const LobeLongCatAI = createOpenAICompatibleRuntime({
     handlePayload: (payload) => {
       const { frequency_penalty, presence_penalty, ...rest } = payload;
 
-      const messages = payload.messages.map((message) => ({
-        ...message,
-        content: transformLongCatMessage(message.content),
-      }));
-
       return {
         ...rest,
+        ...(payload.model.includes('Omni') && {
+          messages: payload.messages.map((message) => ({
+            ...message,
+            content: transformLongCatMessage(message.content),
+          })),
+          output_modalities: ['text'],
+        }),
         frequency_penalty: undefined,
-        messages,
         presence_penalty: undefined,
         stream: true,
       } as any;

--- a/packages/model-runtime/src/providers/longcat/index.ts
+++ b/packages/model-runtime/src/providers/longcat/index.ts
@@ -1,5 +1,6 @@
 import { ModelProvider } from 'model-bank';
 
+import { transformLongCatMessage } from '../../core/contextBuilders/longcat';
 import { createOpenAICompatibleRuntime } from '../../core/openaiCompatibleFactory';
 
 export const LobeLongCatAI = createOpenAICompatibleRuntime({
@@ -8,9 +9,15 @@ export const LobeLongCatAI = createOpenAICompatibleRuntime({
     handlePayload: (payload) => {
       const { frequency_penalty, presence_penalty, ...rest } = payload;
 
+      const messages = payload.messages.map((message) => ({
+        ...message,
+        content: transformLongCatMessage(message.content),
+      }));
+
       return {
         ...rest,
         frequency_penalty: undefined,
+        messages,
         presence_penalty: undefined,
         stream: true,
       } as any;


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

为 LongCat 运行时添加多模态感知支持，并更新可用的 LongCat 模型。

新特性：
- 在模型库中注册具有多模态能力的 LongCat-Flash-Omni-2603 聊天模型。
- 引入 LongCat 专用消息转换器，以在兼容 OpenAI 的请求中支持图像和视频内容。

优化与改进：
- 更新 LongCat 模型元数据，包括启用基础的 LongCat-Flash-Thinking 模型并刷新其发布日期。
- 将 LongCat 运行时接入新的转换器，对传入消息进行标准化处理，同时从负载中清理不受支持的采样参数。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add multimodal-aware LongCat runtime support and update available LongCat models.

New Features:
- Register the LongCat-Flash-Omni-2603 chat model with multimodal capabilities in the model bank.
- Introduce a LongCat-specific message transformer to support image and video content in OpenAI-compatible requests.

Enhancements:
- Update LongCat model metadata, including enabling the base LongCat-Flash-Thinking model and refreshing its release date.
- Wire the LongCat runtime to normalize incoming messages via the new transformer while cleaning unsupported sampling parameters from the payload.

</details>