### PR TITLE
style: add seedance 1.5 support for OSS

### DIFF
--- a/packages/model-bank/src/aiModels/volcengine.ts
+++ b/packages/model-bank/src/aiModels/volcengine.ts
@@ -1,4 +1,9 @@
-import { type AIChatModelCard, type AIImageModelCard } from '../types/aiModel';
+import {
+  type AIChatModelCard,
+  type AIImageModelCard,
+  type AIVideoModelCard,
+} from '../types/aiModel';
+import { seedance15ProParams } from './lobehub/video';
 
 // https://www.volcengine.com/docs/82379/1330310
 
@@ -1244,6 +1249,35 @@ const volcengineImageModels: AIImageModelCard[] = [
   },
 ];
 
-export const allModels = [...doubaoChatModels, ...volcengineImageModels];
+const volcengineVideoModels: AIVideoModelCard[] = [
+  {
+    description:
+      'Seedance 1.5 Pro by ByteDance supports text-to-video, image-to-video (first frame, first+last frame), and audio generation synchronized with visuals.',
+    displayName: 'Seedance 1.5 Pro',
+    enabled: true,
+    id: 'doubao-seedance-1-5-pro-251215',
+    organization: 'ByteDance',
+    parameters: seedance15ProParams,
+    pricing: {
+      approximatePricePerVideo: 0.25,
+      currency: 'CNY',
+      units: [
+        {
+          lookup: {
+            pricingParams: ['generateAudio'],
+            prices: { false: 1.2, true: 2.4 },
+          },
+          name: 'videoGeneration',
+          strategy: 'lookup',
+          unit: 'millionTokens',
+        },
+      ],
+    },
+    releasedAt: '2025-12-15',
+    type: 'video',
+  },
+];
+
+export const allModels = [...doubaoChatModels, ...volcengineImageModels, ...volcengineVideoModels];
 
 export default allModels;

--- a/src/app/(backend)/api/webhooks/video/[provider]/route.ts
+++ b/src/app/(backend)/api/webhooks/video/[provider]/route.ts
@@ -50,8 +50,9 @@ export const POST = async (req: Request, { params }: { params: Promise<{ provide
   let asyncTaskMetadata: VideoGenerationTaskMetadata | undefined;
 
   try {
-    // Parse webhook body using provider-specific handler
-    const runtime = ModelRuntime.initializeWithProvider(provider, {});
+    const runtime = ModelRuntime.initializeWithProvider(provider, {
+      apiKey: 'webhook-placeholder',
+    });
     const result = await runtime.handleCreateVideoWebhook({ body });
 
     if (!result) {


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

添加对字节跳动 Seedance 1.5 Pro 视频模型的支持，并通过使用占位 API Key 初始化模型运行时，确保可以正确处理视频 webhook。

新特性：
- 在 Volcengine 模型目录中引入字节跳动 Seedance 1.5 Pro 视频生成模型，包括其定价元数据。

增强内容：
- 将 Volcengine 视频模型纳入统一的 `allModels` 导出中，便于模型发现与使用。
- 使用包含占位 API Key 的、特定于提供商的运行时初始化视频 webhook 处理，以满足提供商解析需求。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for the Seedance 1.5 Pro video model from ByteDance and ensure video webhooks can be processed by initializing the model runtime with a placeholder API key.

New Features:
- Introduce the Seedance 1.5 Pro ByteDance video generation model, including pricing metadata, into the Volcengine model catalog.

Enhancements:
- Include Volcengine video models in the unified allModels export for model discovery and usage.
- Initialize video webhook handling with a provider-specific runtime that includes a placeholder API key to support provider parsing requirements.

</details>