### PR TITLE
💄 style: add keling provider for AIGC

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -197,6 +197,12 @@ OPENAI_API_KEY=sk-xxxxxxxxx
 
 # FAL_API_KEY=fal-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
+# ## KELING ###
+
+# KELING_ACCESS_KEY=your-keling-access-key
+# KELING_SECRET_KEY=your-keling-secret-key
+# KELING_PROXY_URL=https://api-beijing.klingai.com
+
 # #######################################
 # ######## AI Image Settings ############
 # #######################################

--- a/packages/model-bank/src/aiModels/index.ts
+++ b/packages/model-bank/src/aiModels/index.ts
@@ -31,6 +31,7 @@ import { default as hunyuan } from './hunyuan';
 import { default as infiniai } from './infiniai';
 import { default as internlm } from './internlm';
 import { default as jina } from './jina';
+import { default as keling } from './keling';
 import { default as lmstudio } from './lmstudio';
 import { default as lobehub } from './lobehub/index';
 import { default as longcat } from './longcat';
@@ -125,6 +126,7 @@ export const LOBE_DEFAULT_MODEL_LIST = buildDefaultModelList({
   infiniai,
   internlm,
   jina,
+  keling,
   lmstudio,
   longcat,
   ...(ENABLE_BUSINESS_FEATURES ? { lobehub } : {}),
@@ -200,6 +202,7 @@ export { default as hunyuan } from './hunyuan';
 export { default as infiniai } from './infiniai';
 export { default as internlm } from './internlm';
 export { default as jina } from './jina';
+export { default as keling } from './keling';
 export { default as lmstudio } from './lmstudio';
 export { default as lobehub } from './lobehub/index';
 export { default as longcat } from './longcat';

--- a/packages/model-bank/src/aiModels/keling.ts
+++ b/packages/model-bank/src/aiModels/keling.ts
@@ -1,0 +1,59 @@
+import type { ModelParamsSchema } from '../standard-parameters';
+import { PRESET_ASPECT_RATIOS } from '../standard-parameters';
+import type { AIImageModelCard } from '../types';
+
+const kelingImageParamsSchema: ModelParamsSchema = {
+  aspectRatio: {
+    default: '1:1',
+    enum: PRESET_ASPECT_RATIOS,
+  },
+  imageUrls: {
+    default: [],
+    maxCount: 4,
+  },
+  prompt: { default: '' },
+  resolution: {
+    default: '2k',
+    enum: ['1k', '2k'],
+  },
+  seed: { default: null },
+};
+
+const kelingV21ParamsSchema: ModelParamsSchema = {
+  aspectRatio: {
+    default: '1:1',
+    enum: PRESET_ASPECT_RATIOS,
+  },
+  imageUrl: { default: null },
+  imageUrls: {
+    default: [],
+    maxCount: 4,
+  },
+  prompt: { default: '' },
+  seed: { default: null },
+};
+
+const imageModels: AIImageModelCard[] = [
+  {
+    description:
+      'Advanced multi-image fusion and generation model for complex visual compositions.',
+    displayName: 'Keling Image O1',
+    enabled: true,
+    id: 'kling-image-o1',
+    parameters: kelingImageParamsSchema,
+    type: 'image',
+  },
+  {
+    description:
+      'Versatile image generation and editing model supporting text-to-image and image-to-image.',
+    displayName: 'Keling V2.1',
+    enabled: true,
+    id: 'kling-v2-1',
+    parameters: kelingV21ParamsSchema,
+    type: 'image',
+  },
+];
+
+export const allModels = [...imageModels];
+
+export default allModels;

--- a/packages/model-bank/src/aiModels/keling.ts
+++ b/packages/model-bank/src/aiModels/keling.ts
@@ -1,6 +1,8 @@
 import type { ModelParamsSchema } from '../standard-parameters';
 import { PRESET_ASPECT_RATIOS } from '../standard-parameters';
-import type { AIImageModelCard } from '../types';
+import type { VideoModelParamsSchema } from '../standard-parameters/video';
+import { PRESET_VIDEO_ASPECT_RATIOS } from '../standard-parameters/video';
+import type { AIImageModelCard, AIVideoModelCard } from '../types';
 
 const kelingImageParamsSchema: ModelParamsSchema = {
   aspectRatio: {
@@ -54,6 +56,112 @@ const imageModels: AIImageModelCard[] = [
   },
 ];
 
-export const allModels = [...imageModels];
+const klingVideoV26ParamsSchema: VideoModelParamsSchema = {
+  aspectRatio: {
+    default: '16:9',
+    enum: PRESET_VIDEO_ASPECT_RATIOS,
+  },
+  duration: {
+    default: 5,
+    max: 10,
+    min: 3,
+    step: 1,
+  },
+  endImageUrl: {
+    default: null,
+    requiresImageUrl: true,
+  },
+  imageUrl: {
+    default: null,
+  },
+  prompt: {
+    default: '',
+  },
+};
+
+const klingVideoO1ParamsSchema: VideoModelParamsSchema = {
+  aspectRatio: {
+    default: '16:9',
+    enum: PRESET_VIDEO_ASPECT_RATIOS,
+  },
+  duration: {
+    default: 5,
+    max: 10,
+    min: 3,
+    step: 1,
+  },
+  endImageUrl: {
+    default: null,
+  },
+  imageUrl: {
+    default: null,
+  },
+  prompt: {
+    default: '',
+  },
+};
+
+const klingV3OmniParamsSchema: VideoModelParamsSchema = {
+  aspectRatio: {
+    default: '16:9',
+    enum: PRESET_VIDEO_ASPECT_RATIOS,
+  },
+  duration: {
+    default: 5,
+    max: 15,
+    min: 3,
+    step: 1,
+  },
+  endImageUrl: {
+    default: null,
+  },
+  imageUrl: {
+    default: null,
+  },
+  prompt: {
+    default: '',
+  },
+};
+
+const videoModels: AIVideoModelCard[] = [
+  {
+    description:
+      'Advanced video generation model supporting text-to-video, image-to-video, and first-last frame generation. Supports sound control.',
+    displayName: 'Keling V2.6',
+    enabled: true,
+    id: 'kling-v2-6',
+    parameters: klingVideoV26ParamsSchema,
+    type: 'video',
+  },
+  {
+    description:
+      'Professional video generation model supporting text-to-video and image-to-video. Standard and Pro modes with 3-10s duration.',
+    displayName: 'Keling Video O1',
+    enabled: true,
+    id: 'kling-video-o1',
+    parameters: klingVideoO1ParamsSchema,
+    type: 'video',
+  },
+  {
+    description:
+      'Advanced omni video generation model with multi-shot support. Standard and Pro modes with 3-15s duration.',
+    displayName: 'Keling V3 Omni',
+    enabled: true,
+    id: 'kling-v3-omni',
+    parameters: klingV3OmniParamsSchema,
+    type: 'video',
+  },
+  {
+    description:
+      'Multi-image video generation model. Supports subject control with multiple reference images.',
+    displayName: 'Keling V1.6',
+    enabled: true,
+    id: 'kling-v1-6',
+    parameters: klingVideoV26ParamsSchema,
+    type: 'video',
+  },
+];
+
+export const allModels = [...imageModels, ...videoModels];
 
 export default allModels;

--- a/packages/model-bank/src/const/modelProvider.ts
+++ b/packages/model-bank/src/const/modelProvider.ts
@@ -29,6 +29,7 @@ export enum ModelProvider {
   InfiniAI = 'infiniai',
   InternLM = 'internlm',
   Jina = 'jina',
+  Keling = 'keling',
   LMStudio = 'lmstudio',
   LobeHub = 'lobehub',
   LongCat = 'longcat',

--- a/packages/model-bank/src/modelProviders/index.ts
+++ b/packages/model-bank/src/modelProviders/index.ts
@@ -249,6 +249,7 @@ export { default as HunyuanProviderCard } from './hunyuan';
 export { default as InfiniAIProviderCard } from './infiniai';
 export { default as InternLMProviderCard } from './internlm';
 export { default as JinaProviderCard } from './jina';
+export { default as KelingProviderCard } from './keling';
 export { default as LMStudioProviderCard } from './lmstudio';
 export { default as LobeHubProviderCard } from './lobehub';
 export { default as LongCatProviderCard } from './longcat';

--- a/packages/model-bank/src/modelProviders/keling.ts
+++ b/packages/model-bank/src/modelProviders/keling.ts
@@ -1,0 +1,19 @@
+import type { ModelProviderCard } from '@/types/llm';
+
+const Keling: ModelProviderCard = {
+  chatModels: [],
+  description:
+    'Keling AI is a powerful image generation platform offering advanced AI-driven visual creation capabilities.',
+  enabled: true,
+  id: 'keling',
+  name: 'Keling',
+  settings: {
+    disableBrowserRequest: true,
+    showAddNewModel: false,
+    showChecker: false,
+    showModelFetcher: false,
+  },
+  url: 'https://klingai.com/',
+};
+
+export default Keling;

--- a/packages/model-runtime/src/providers/keling/createImage.ts
+++ b/packages/model-runtime/src/providers/keling/createImage.ts
@@ -24,7 +24,7 @@ const log = createDebug('lobe-image:keling');
 const BASE_URL = 'https://api-beijing.klingai.com';
 
 interface KelingCreateImageOptions {
-  accessKey: string;
+  apiKey: string;
   baseURL?: string;
   provider: string;
   secretKey: string;
@@ -184,8 +184,8 @@ async function buildRequestPayload(
   }
 }
 
-function generateAuthToken(accessKey: string, secretKey: string): string {
-  const token = createJWT(accessKey, secretKey, 1800);
+function generateAuthToken(apiKey: string, secretKey: string): string {
+  const token = createJWT(apiKey, secretKey, 1800);
   return `Bearer ${token}`;
 }
 
@@ -195,7 +195,7 @@ async function submitTask(
   options: KelingCreateImageOptions,
 ): Promise<KelingSubmitResponse> {
   const url = `${options.baseURL || BASE_URL}${endpoint}`;
-  const authToken = generateAuthToken(options.accessKey, options.secretKey);
+  const authToken = generateAuthToken(options.apiKey, options.secretKey);
 
   log('Submitting task to: %s', url);
 
@@ -233,7 +233,7 @@ async function queryTaskStatus(
   options: KelingCreateImageOptions,
 ): Promise<KelingQueryResponse> {
   const url = `${options.baseURL || BASE_URL}${endpoint}/${taskId}`;
-  const authToken = generateAuthToken(options.accessKey, options.secretKey);
+  const authToken = generateAuthToken(options.apiKey, options.secretKey);
 
   log('Querying task status for ID: %s', taskId);
 

--- a/packages/model-runtime/src/providers/keling/createImage.ts
+++ b/packages/model-runtime/src/providers/keling/createImage.ts
@@ -1,0 +1,366 @@
+import { imageUrlToBase64 } from '@lobechat/utils';
+import createDebug from 'debug';
+
+import { AgentRuntimeErrorType } from '../../types/error';
+import type { CreateImagePayload, CreateImageResponse } from '../../types/image';
+import type { TaskResult } from '../../utils/asyncifyPolling';
+import { asyncifyPolling } from '../../utils/asyncifyPolling';
+import { AgentRuntimeError } from '../../utils/createError';
+import { parseDataUri } from '../../utils/uriParser';
+import { createJWT } from './jwt';
+import type {
+  KelingGenerationsRequest,
+  KelingModelId,
+  KelingMultiImage2ImageRequest,
+  KelingOmniImageRequest,
+  KelingQueryResponse,
+  KelingRequest,
+  KelingSubmitResponse,
+} from './types';
+import { KELING_ENDPOINTS, KELING_MULTI_IMAGE_ENDPOINT, KelingTaskStatus } from './types';
+
+const log = createDebug('lobe-image:keling');
+
+const BASE_URL = 'https://api-beijing.klingai.com';
+
+interface KelingCreateImageOptions {
+  accessKey: string;
+  baseURL?: string;
+  provider: string;
+  secretKey: string;
+}
+
+async function convertImageToBase64(imageUrl: string): Promise<string> {
+  try {
+    const { type } = parseDataUri(imageUrl);
+
+    if (type === 'base64') {
+      const base64Match = imageUrl.match(/^data:[^;]+;base64,(.+)$/);
+      if (base64Match) {
+        return base64Match[1];
+      }
+      throw new Error('Invalid base64 format');
+    }
+
+    if (type === 'url') {
+      const { base64 } = await imageUrlToBase64(imageUrl);
+      return base64;
+    }
+
+    throw new Error(`Invalid image URL format: ${imageUrl}`);
+  } catch (error) {
+    log('Error converting image to base64: %O', error);
+    throw error;
+  }
+}
+
+async function buildOmniImageRequest(
+  model: KelingModelId,
+  params: CreateImagePayload['params'],
+): Promise<KelingOmniImageRequest> {
+  log('Building omni-image request for model: %s', model);
+
+  const payload: KelingOmniImageRequest = {
+    model_name: 'kling-image-o1',
+    prompt: params.prompt || '',
+  };
+
+  if (params.aspectRatio) {
+    payload.aspect_ratio = params.aspectRatio;
+  }
+
+  const p = params as any;
+  if (p.n) {
+    payload.n = p.n as number;
+  }
+
+  if (params.resolution) {
+    payload.resolution = params.resolution as '2k' | '1k';
+  }
+
+  if (p.imageUrls && p.imageUrls.length > 0) {
+    payload.image_list = await Promise.all(
+      p.imageUrls.slice(0, 4).map(async (url: string) => ({
+        image: await convertImageToBase64(url),
+      })),
+    );
+  }
+
+  if (p.elementIds && p.elementIds.length > 0) {
+    payload.element_list = p.elementIds.map((id: number) => ({ element_id: id }));
+  }
+
+  return payload;
+}
+
+async function buildGenerationsRequest(
+  model: KelingModelId,
+  params: CreateImagePayload['params'],
+): Promise<KelingGenerationsRequest> {
+  log('Building generations request for model: %s', model);
+
+  const payload: KelingGenerationsRequest = {
+    model_name: 'kling-v2-1',
+    prompt: params.prompt || '',
+  };
+
+  const p = params as any;
+  if (p.negativePrompt) {
+    payload.negative_prompt = p.negativePrompt;
+  }
+
+  if (p.n) {
+    payload.n = p.n as number;
+  }
+
+  if (params.imageUrl) {
+    payload.image = await convertImageToBase64(params.imageUrl);
+  }
+
+  return payload;
+}
+
+async function buildMultiImage2ImageRequest(
+  model: KelingModelId,
+  params: CreateImagePayload['params'],
+): Promise<KelingMultiImage2ImageRequest> {
+  log('Building multi-image2image request for model: %s', model);
+
+  const payload: KelingMultiImage2ImageRequest = {
+    model_name: 'kling-v2-1',
+    prompt: params.prompt || '',
+  };
+
+  const p = params as any;
+  if (p.negativePrompt) {
+    payload.negative_prompt = p.negativePrompt;
+  }
+
+  if (p.n) {
+    payload.n = p.n as number;
+  }
+
+  if (params.aspectRatio) {
+    payload.aspect_ratio = params.aspectRatio;
+  }
+
+  if (p.imageUrls && p.imageUrls.length >= 2) {
+    payload.subject_image_list = await Promise.all(
+      p.imageUrls.slice(0, 2).map(async (url: string) => ({
+        subject_image: await convertImageToBase64(url),
+      })),
+    );
+
+    if (p.imageUrls.length > 2) {
+      payload.scene_image = await convertImageToBase64(p.imageUrls[2]);
+    }
+
+    if (p.imageUrls.length > 3) {
+      payload.style_image = await convertImageToBase64(p.imageUrls[3]);
+    }
+  } else if (params.imageUrl) {
+    payload.scene_image = await convertImageToBase64(params.imageUrl);
+  }
+
+  return payload;
+}
+
+async function buildRequestPayload(
+  model: KelingModelId,
+  params: CreateImagePayload['params'],
+  endpoint: string,
+): Promise<KelingRequest> {
+  switch (endpoint) {
+    case KELING_ENDPOINTS['kling-image-o1']: {
+      return buildOmniImageRequest(model, params);
+    }
+    case KELING_MULTI_IMAGE_ENDPOINT: {
+      return buildMultiImage2ImageRequest(model, params);
+    }
+    case KELING_ENDPOINTS['kling-v2-1']:
+    default: {
+      return buildGenerationsRequest(model, params);
+    }
+  }
+}
+
+function generateAuthToken(accessKey: string, secretKey: string): string {
+  const token = createJWT(accessKey, secretKey, 1800);
+  return `Bearer ${token}`;
+}
+
+async function submitTask(
+  endpoint: string,
+  payload: KelingRequest,
+  options: KelingCreateImageOptions,
+): Promise<KelingSubmitResponse> {
+  const url = `${options.baseURL || BASE_URL}${endpoint}`;
+  const authToken = generateAuthToken(options.accessKey, options.secretKey);
+
+  log('Submitting task to: %s', url);
+
+  const response = await fetch(url, {
+    body: JSON.stringify(payload),
+    headers: {
+      'Authorization': authToken,
+      'Content-Type': 'application/json',
+    },
+    method: 'POST',
+  });
+
+  if (!response.ok) {
+    let errorData;
+    try {
+      errorData = await response.json();
+    } catch {
+      errorData = null;
+    }
+
+    throw new Error(
+      `Keling API error (${response.status}): ${errorData?.message || response.statusText}`,
+    );
+  }
+
+  const data: KelingSubmitResponse = await response.json();
+  log('Task submitted successfully with ID: %s', data.data.task_id);
+
+  return data;
+}
+
+async function queryTaskStatus(
+  taskId: string,
+  endpoint: string,
+  options: KelingCreateImageOptions,
+): Promise<KelingQueryResponse> {
+  const url = `${options.baseURL || BASE_URL}${endpoint}/${taskId}`;
+  const authToken = generateAuthToken(options.accessKey, options.secretKey);
+
+  log('Querying task status for ID: %s', taskId);
+
+  const response = await fetch(url, {
+    headers: {
+      'Authorization': authToken,
+      'Content-Type': 'application/json',
+    },
+    method: 'GET',
+  });
+
+  if (!response.ok) {
+    let errorData;
+    try {
+      errorData = await response.json();
+    } catch {
+      errorData = null;
+    }
+
+    throw new Error(
+      `Failed to query task status (${response.status}): ${errorData?.message || response.statusText}`,
+    );
+  }
+
+  return response.json();
+}
+
+function getEndpointForModel(model: KelingModelId, params: CreateImagePayload['params']): string {
+  if (model === 'kling-image-o1') {
+    return KELING_ENDPOINTS['kling-image-o1'];
+  }
+
+  if (model === 'kling-v2-1') {
+    const p = params as any;
+    if (p.imageUrls && p.imageUrls.length >= 2) {
+      return KELING_MULTI_IMAGE_ENDPOINT;
+    }
+    return KELING_ENDPOINTS['kling-v2-1'];
+  }
+
+  return KELING_ENDPOINTS['kling-v2-1'];
+}
+
+export async function createKelingImage(
+  payload: CreateImagePayload,
+  options: KelingCreateImageOptions,
+): Promise<CreateImageResponse> {
+  const { model, params } = payload;
+
+  const endpoint = getEndpointForModel(model as KelingModelId, params);
+
+  if (
+    !Object.values(KELING_ENDPOINTS).includes(endpoint as any) &&
+    endpoint !== KELING_MULTI_IMAGE_ENDPOINT
+  ) {
+    throw AgentRuntimeError.createImage({
+      error: new Error(`Unsupported Keling model: ${model}`),
+      errorType: AgentRuntimeErrorType.ModelNotFound,
+      provider: options.provider,
+    });
+  }
+
+  try {
+    const requestPayload = await buildRequestPayload(model as KelingModelId, params, endpoint);
+
+    const taskResponse = await submitTask(endpoint, requestPayload, options);
+    const taskId = taskResponse.data.task_id;
+
+    return await asyncifyPolling<KelingQueryResponse, CreateImageResponse>({
+      backoffMultiplier: 1.5,
+      checkStatus: (taskStatus: KelingQueryResponse): TaskResult<CreateImageResponse> => {
+        log('Task %s status: %s', taskId, taskStatus.data.task_status);
+
+        switch (taskStatus.data.task_status) {
+          case KelingTaskStatus.Succeed: {
+            const images =
+              taskStatus.data.task_result?.images || taskStatus.data.task_result?.series_images;
+
+            if (!images || images.length === 0) {
+              return {
+                error: new Error('Task succeeded but no image generated'),
+                status: 'failed',
+              };
+            }
+
+            const imageUrl = images[0].url;
+            log('Image generated successfully: %s', imageUrl);
+
+            return {
+              data: { imageUrl },
+              status: 'success',
+            };
+          }
+
+          case KelingTaskStatus.Failed: {
+            const errorMessage =
+              taskStatus.data.task_status_msg ||
+              `Image generation failed with status: ${taskStatus.data.task_status}`;
+
+            return {
+              error: new Error(errorMessage),
+              status: 'failed',
+            };
+          }
+
+          default: {
+            return { status: 'pending' };
+          }
+        }
+      },
+      initialInterval: 1000,
+      logger: {
+        debug: (message: any, ...args: any[]) => log(message, ...args),
+        error: (message: any, ...args: any[]) => log(message, ...args),
+      },
+      maxConsecutiveFailures: 5,
+      maxInterval: 5000,
+      maxRetries: 60,
+      pollingQuery: () => queryTaskStatus(taskId, endpoint, options),
+    });
+  } catch (error) {
+    log('Error in createKelingImage: %O', error);
+
+    throw AgentRuntimeError.createImage({
+      error: error as any,
+      errorType: AgentRuntimeErrorType.ProviderBizError,
+      provider: options.provider,
+    });
+  }
+}

--- a/packages/model-runtime/src/providers/keling/createImage.ts
+++ b/packages/model-runtime/src/providers/keling/createImage.ts
@@ -177,15 +177,14 @@ async function buildRequestPayload(
     case KELING_MULTI_IMAGE_ENDPOINT: {
       return buildMultiImage2ImageRequest(model, params);
     }
-    case KELING_ENDPOINTS['kling-v2-1']:
     default: {
       return buildGenerationsRequest(model, params);
     }
   }
 }
 
-function generateAuthToken(apiKey: string, secretKey: string): string {
-  const token = createJWT(apiKey, secretKey, 1800);
+async function generateAuthToken(apiKey: string, secretKey: string): Promise<string> {
+  const token = await createJWT(apiKey, secretKey, 1800);
   return `Bearer ${token}`;
 }
 
@@ -195,7 +194,7 @@ async function submitTask(
   options: KelingCreateImageOptions,
 ): Promise<KelingSubmitResponse> {
   const url = `${options.baseURL || BASE_URL}${endpoint}`;
-  const authToken = generateAuthToken(options.apiKey, options.secretKey);
+  const authToken = await generateAuthToken(options.apiKey, options.secretKey);
 
   log('Submitting task to: %s', url);
 
@@ -233,7 +232,7 @@ async function queryTaskStatus(
   options: KelingCreateImageOptions,
 ): Promise<KelingQueryResponse> {
   const url = `${options.baseURL || BASE_URL}${endpoint}/${taskId}`;
-  const authToken = generateAuthToken(options.apiKey, options.secretKey);
+  const authToken = await generateAuthToken(options.apiKey, options.secretKey);
 
   log('Querying task status for ID: %s', taskId);
 

--- a/packages/model-runtime/src/providers/keling/index.ts
+++ b/packages/model-runtime/src/providers/keling/index.ts
@@ -11,7 +11,7 @@ const log = createDebug('lobe-image:keling');
 
 export class LobeKelingAI implements LobeRuntimeAI {
   baseURL?: string;
-  private accessKey: string;
+  private apiKey: string;
   private secretKey: string;
 
   constructor({ apiKey, baseURL, secretKey }: ClientOptions & { secretKey?: string } = {}) {
@@ -21,15 +21,15 @@ export class LobeKelingAI implements LobeRuntimeAI {
 
     if (!secretKey) {
       throw AgentRuntimeError.createError(AgentRuntimeErrorType.InvalidProviderAPIKey, {
-        message: 'Keling requires both accessKey and secretKey',
+        message: 'Keling requires both apiKey and secretKey',
       });
     }
 
-    this.accessKey = apiKey;
+    this.apiKey = apiKey;
     this.secretKey = secretKey;
     this.baseURL = baseURL || undefined;
 
-    log('Keling AI initialized with accessKey: %s', apiKey.slice(0, 8) + '...');
+    log('Keling AI initialized with apiKey: %s', apiKey.slice(0, 8) + '...');
   }
 
   async createImage(payload: CreateImagePayload): Promise<CreateImageResponse> {
@@ -38,7 +38,7 @@ export class LobeKelingAI implements LobeRuntimeAI {
 
     try {
       return await createKelingImage(payload, {
-        accessKey: this.accessKey,
+        apiKey: this.apiKey,
         baseURL: this.baseURL,
         provider: 'keling',
         secretKey: this.secretKey,

--- a/packages/model-runtime/src/providers/keling/index.ts
+++ b/packages/model-runtime/src/providers/keling/index.ts
@@ -1,0 +1,66 @@
+import createDebug from 'debug';
+import type { ClientOptions } from 'openai';
+
+import type { LobeRuntimeAI } from '../../core/BaseAI';
+import { AgentRuntimeErrorType } from '../../types/error';
+import type { CreateImagePayload, CreateImageResponse } from '../../types/image';
+import { AgentRuntimeError } from '../../utils/createError';
+import { createKelingImage } from './createImage';
+
+const log = createDebug('lobe-image:keling');
+
+export class LobeKelingAI implements LobeRuntimeAI {
+  baseURL?: string;
+  private accessKey: string;
+  private secretKey: string;
+
+  constructor({ apiKey, baseURL, secretKey }: ClientOptions & { secretKey?: string } = {}) {
+    if (!apiKey) {
+      throw AgentRuntimeError.createError(AgentRuntimeErrorType.InvalidProviderAPIKey);
+    }
+
+    if (!secretKey) {
+      throw AgentRuntimeError.createError(AgentRuntimeErrorType.InvalidProviderAPIKey, {
+        message: 'Keling requires both accessKey and secretKey',
+      });
+    }
+
+    this.accessKey = apiKey;
+    this.secretKey = secretKey;
+    this.baseURL = baseURL || undefined;
+
+    log('Keling AI initialized with accessKey: %s', apiKey.slice(0, 8) + '...');
+  }
+
+  async createImage(payload: CreateImagePayload): Promise<CreateImageResponse> {
+    const { model, params } = payload;
+    log('Creating image with model: %s and params: %O', model, params);
+
+    try {
+      return await createKelingImage(payload, {
+        accessKey: this.accessKey,
+        baseURL: this.baseURL,
+        provider: 'keling',
+        secretKey: this.secretKey,
+      });
+    } catch (error) {
+      log('Error in createImage: %O', error);
+
+      if (error instanceof Error && 'status' in error && (error as any).status === 401) {
+        throw AgentRuntimeError.createError(AgentRuntimeErrorType.InvalidProviderAPIKey, {
+          error,
+        });
+      }
+
+      if (error instanceof Error && error.message.includes('secretKey')) {
+        throw AgentRuntimeError.createError(AgentRuntimeErrorType.InvalidProviderAPIKey, {
+          error,
+        });
+      }
+
+      throw AgentRuntimeError.createError(AgentRuntimeErrorType.ProviderBizError, { error });
+    }
+  }
+}
+
+export default LobeKelingAI;

--- a/packages/model-runtime/src/providers/keling/index.ts
+++ b/packages/model-runtime/src/providers/keling/index.ts
@@ -4,10 +4,13 @@ import type { ClientOptions } from 'openai';
 import type { LobeRuntimeAI } from '../../core/BaseAI';
 import { AgentRuntimeErrorType } from '../../types/error';
 import type { CreateImagePayload, CreateImageResponse } from '../../types/image';
+import type { CreateVideoPayload, CreateVideoResponse } from '../../types/video';
 import { AgentRuntimeError } from '../../utils/createError';
 import { createKelingImage } from './createImage';
+import { createKelingVideo } from './video/createVideo';
 
 const log = createDebug('lobe-image:keling');
+const videoLog = createDebug('lobe-video:keling');
 
 export class LobeKelingAI implements LobeRuntimeAI {
   baseURL?: string;
@@ -53,6 +56,30 @@ export class LobeKelingAI implements LobeRuntimeAI {
       }
 
       if (error instanceof Error && error.message.includes('secretKey')) {
+        throw AgentRuntimeError.createError(AgentRuntimeErrorType.InvalidProviderAPIKey, {
+          error,
+        });
+      }
+
+      throw AgentRuntimeError.createError(AgentRuntimeErrorType.ProviderBizError, { error });
+    }
+  }
+
+  async createVideo(payload: CreateVideoPayload): Promise<CreateVideoResponse> {
+    const { model, params } = payload;
+    videoLog('Creating video with model: %s and params: %O', model, params);
+
+    try {
+      return await createKelingVideo(payload, {
+        apiKey: this.apiKey,
+        baseURL: this.baseURL,
+        provider: 'keling',
+        secretKey: this.secretKey,
+      });
+    } catch (error) {
+      videoLog('Error in createVideo: %O', error);
+
+      if (error instanceof Error && 'status' in error && (error as any).status === 401) {
         throw AgentRuntimeError.createError(AgentRuntimeErrorType.InvalidProviderAPIKey, {
           error,
         });

--- a/packages/model-runtime/src/providers/keling/jwt.ts
+++ b/packages/model-runtime/src/providers/keling/jwt.ts
@@ -1,0 +1,66 @@
+import { createHmac, randomUUID } from 'node:crypto';
+
+function base64UrlEncode(buffer: Buffer): string {
+  return buffer.toString('base64url').replaceAll('=', '');
+}
+
+function base64UrlJsonEncode(obj: Record<string, any>): string {
+  const json = JSON.stringify(obj);
+  return base64UrlEncode(Buffer.from(json, 'utf-8'));
+}
+
+export function createJWT(accessKey: string, secretKey: string, expiresIn: number = 1800): string {
+  const now = Math.floor(Date.now() / 1000);
+
+  const header = {
+    alg: 'HS256',
+    typ: 'JWT',
+  };
+
+  const payload = {
+    exp: now + expiresIn,
+    iat: now,
+    iss: accessKey,
+    jti: randomUUID(),
+    nbf: now - 5,
+  };
+
+  const encodedHeader = base64UrlJsonEncode(header);
+  const encodedPayload = base64UrlJsonEncode(payload);
+
+  const signatureInput = `${encodedHeader}.${encodedPayload}`;
+  const signature = createHmac('sha256', secretKey).update(signatureInput).digest('base64url');
+
+  return `${encodedHeader}.${encodedPayload}.${signature}`;
+}
+
+export function verifyJWT(token: string, secretKey: string): { valid: boolean; payload?: any } {
+  try {
+    const parts = token.split('.');
+    if (parts.length !== 3) {
+      return { valid: false };
+    }
+
+    const [encodedHeader, encodedPayload, signature] = parts;
+
+    const signatureInput = `${encodedHeader}.${encodedPayload}`;
+    const expectedSignature = createHmac('sha256', secretKey)
+      .update(signatureInput)
+      .digest('base64url');
+
+    if (signature !== expectedSignature) {
+      return { valid: false };
+    }
+
+    const payload = JSON.parse(Buffer.from(encodedPayload, 'base64url').toString('utf-8'));
+
+    const now = Math.floor(Date.now() / 1000);
+    if (payload.exp < now) {
+      return { valid: false, payload };
+    }
+
+    return { valid: true, payload };
+  } catch {
+    return { valid: false };
+  }
+}

--- a/packages/model-runtime/src/providers/keling/jwt.ts
+++ b/packages/model-runtime/src/providers/keling/jwt.ts
@@ -1,15 +1,40 @@
-import { createHmac, randomUUID } from 'node:crypto';
+import { nanoid } from 'nanoid';
 
-function base64UrlEncode(buffer: Buffer): string {
-  return buffer.toString('base64url').replaceAll('=', '');
+function base64UrlEncode(buffer: ArrayBuffer): string {
+  return btoa(String.fromCharCode(...new Uint8Array(buffer)))
+    .replaceAll('=', '')
+    .replaceAll('+', '-')
+    .replaceAll('/', '_');
 }
 
 function base64UrlJsonEncode(obj: Record<string, any>): string {
   const json = JSON.stringify(obj);
-  return base64UrlEncode(Buffer.from(json, 'utf-8'));
+  const encoder = new TextEncoder();
+  const data = encoder.encode(json);
+  return base64UrlEncode(data.buffer);
 }
 
-export function createJWT(accessKey: string, secretKey: string, expiresIn: number = 1800): string {
+async function signJWT(data: string, secretKey: string): Promise<string> {
+  const encoder = new TextEncoder();
+  const keyData = encoder.encode(secretKey);
+
+  const key = await crypto.subtle.importKey(
+    'raw',
+    keyData,
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  );
+
+  const signature = await crypto.subtle.sign('HMAC', key, encoder.encode(data));
+  return base64UrlEncode(signature);
+}
+
+export async function createJWT(
+  accessKey: string,
+  secretKey: string,
+  expiresIn: number = 1800,
+): Promise<string> {
   const now = Math.floor(Date.now() / 1000);
 
   const header = {
@@ -21,7 +46,7 @@ export function createJWT(accessKey: string, secretKey: string, expiresIn: numbe
     exp: now + expiresIn,
     iat: now,
     iss: accessKey,
-    jti: randomUUID(),
+    jti: nanoid(),
     nbf: now - 5,
   };
 
@@ -29,38 +54,7 @@ export function createJWT(accessKey: string, secretKey: string, expiresIn: numbe
   const encodedPayload = base64UrlJsonEncode(payload);
 
   const signatureInput = `${encodedHeader}.${encodedPayload}`;
-  const signature = createHmac('sha256', secretKey).update(signatureInput).digest('base64url');
+  const signature = await signJWT(signatureInput, secretKey);
 
   return `${encodedHeader}.${encodedPayload}.${signature}`;
-}
-
-export function verifyJWT(token: string, secretKey: string): { valid: boolean; payload?: any } {
-  try {
-    const parts = token.split('.');
-    if (parts.length !== 3) {
-      return { valid: false };
-    }
-
-    const [encodedHeader, encodedPayload, signature] = parts;
-
-    const signatureInput = `${encodedHeader}.${encodedPayload}`;
-    const expectedSignature = createHmac('sha256', secretKey)
-      .update(signatureInput)
-      .digest('base64url');
-
-    if (signature !== expectedSignature) {
-      return { valid: false };
-    }
-
-    const payload = JSON.parse(Buffer.from(encodedPayload, 'base64url').toString('utf-8'));
-
-    const now = Math.floor(Date.now() / 1000);
-    if (payload.exp < now) {
-      return { valid: false, payload };
-    }
-
-    return { valid: true, payload };
-  } catch {
-    return { valid: false };
-  }
 }

--- a/packages/model-runtime/src/providers/keling/types.ts
+++ b/packages/model-runtime/src/providers/keling/types.ts
@@ -1,0 +1,110 @@
+// Keling API Types
+
+export enum KelingTaskStatus {
+  Failed = 'failed',
+  Processing = 'processing',
+  Submitted = 'submitted',
+  Succeed = 'succeed',
+}
+
+export interface KelingBaseResponse {
+  code: number;
+  message: string;
+  request_id: string;
+}
+
+export interface KelingTaskInfo {
+  external_task_id?: string;
+}
+
+export interface KelingImageResult {
+  index: number;
+  url: string;
+  watermark_url: string;
+}
+
+export interface KelingTaskResult {
+  images?: KelingImageResult[];
+  result_type?: 'single' | 'series';
+  series_images?: KelingImageResult[];
+}
+
+export interface KelingWatermarkInfo {
+  enabled: boolean;
+}
+
+// Task submission response
+export interface KelingSubmitResponse extends KelingBaseResponse {
+  data: {
+    task_id: string;
+    task_info?: KelingTaskInfo;
+    task_status: KelingTaskStatus;
+    created_at: number;
+    updated_at: number;
+  };
+}
+
+// Task query response
+export interface KelingQueryResponse extends KelingBaseResponse {
+  data: {
+    task_id: string;
+    task_status: KelingTaskStatus;
+    task_status_msg?: string;
+    task_info?: KelingTaskInfo;
+    task_result?: KelingTaskResult;
+    watermark_info?: KelingWatermarkInfo;
+    final_unit_deduction?: string;
+    created_at: number;
+    updated_at: number;
+  };
+}
+
+// Model IDs
+export type KelingModelId = 'kling-image-o1' | 'kling-v2-1';
+
+// API endpoints
+export const KELING_ENDPOINTS = {
+  'kling-image-o1': '/v1/images/omni-image',
+  'kling-v2-1': '/v1/images/generations',
+} as const;
+
+// Request types for different endpoints
+export interface KelingOmniImageRequest {
+  aspect_ratio?: string;
+  element_list?: Array<{ element_id: number }>;
+  image_list?: Array<{ image: string }>;
+  model_name: 'kling-image-o1';
+  n?: number;
+  prompt: string;
+  resolution?: '2k' | '1k';
+}
+
+export interface KelingGenerationsRequest {
+  callback_url?: string;
+  external_task_id?: string;
+  image?: string;
+  model_name: 'kling-v2-1';
+  n?: number;
+  negative_prompt?: string;
+  prompt: string;
+}
+
+export interface KelingMultiImage2ImageRequest {
+  aspect_ratio?: string;
+  model_name: 'kling-v2-1';
+  n?: number;
+  negative_prompt?: string;
+  prompt: string;
+  scene_image?: string;
+  style_image?: string;
+  subject_image_list?: Array<{ subject_image: string }>;
+}
+
+// Union type for all request types
+export type KelingRequest =
+  | KelingOmniImageRequest
+  | KelingGenerationsRequest
+  | KelingMultiImage2ImageRequest;
+
+// Multi-image2image endpoint (special case, uses kling-v2-1 but different endpoint)
+export const KELING_MULTI_IMAGE_ENDPOINT = '/v1/images/multi-image2image';

--- a/packages/model-runtime/src/providers/keling/video/createVideo.ts
+++ b/packages/model-runtime/src/providers/keling/video/createVideo.ts
@@ -1,0 +1,192 @@
+import createDebug from 'debug';
+
+import type { CreateVideoPayload, CreateVideoResponse } from '../../../types/video';
+
+const log = createDebug('lobe-video:keling');
+
+const BASE_URL = 'https://api-beijing.klingai.com';
+
+interface KelingCreateVideoOptions {
+  apiKey: string;
+  baseURL?: string;
+  provider: string;
+  secretKey: string;
+}
+
+/**
+ * Keling video generation implementation
+ * Supports three API endpoints:
+ * - /v1/videos/text2video: Text to video
+ * - /v1/videos/image2video: Image to video (first-last frame)
+ * - /v1/videos/multi-image2video: Multi-image to video
+ * API docs: https://klingai.com/
+ */
+export async function createKelingVideo(
+  payload: CreateVideoPayload,
+  options: KelingCreateVideoOptions,
+): Promise<CreateVideoResponse> {
+  const { model, params } = payload;
+  const { prompt, imageUrl, endImageUrl, aspectRatio, duration } = params;
+
+  log('Creating video with Keling API - model: %s, params: %O', model, params);
+
+  const baseURL = options.baseURL || BASE_URL;
+
+  // Determine API endpoint based on input images
+  const endpoint = determineEndpoint(model, { imageUrl, endImageUrl, params });
+
+  // Build request body based on endpoint
+  const body = buildRequestBody(model, {
+    prompt,
+    imageUrl,
+    endImageUrl,
+    aspectRatio,
+    duration,
+    params,
+  });
+
+  log('Keling video API endpoint: %s', endpoint);
+  log('Keling video API request body: %s', JSON.stringify(body, null, 2));
+
+  const authToken = `Bearer ${options.apiKey}:${options.secretKey}`;
+
+  const response = await fetch(`${baseURL}${endpoint}`, {
+    body: JSON.stringify(body),
+    headers: {
+      'Authorization': `Bearer ${authToken}`,
+      'Content-Type': 'application/json',
+    },
+    method: 'POST',
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    log('Keling video API error: %s %s', response.status, errorText);
+    throw new Error(`Keling video API error: ${response.status} ${errorText}`);
+  }
+
+  const data = await response.json();
+
+  log('Keling video API response: %O', data);
+
+  if (data.code !== 0) {
+    throw new Error(`Keling API error: ${data.message || 'Unknown error'}`);
+  }
+
+  if (!data?.data?.task_id) {
+    throw new Error('Invalid response: missing task id');
+  }
+
+  return { inferenceId: data.data.task_id };
+}
+
+/**
+ * Determine which API endpoint to use based on model and input
+ */
+function determineEndpoint(
+  model: string,
+  options: { imageUrl?: string | null; endImageUrl?: string | null; params: any },
+): string {
+  const { imageUrl, endImageUrl, params } = options;
+  const p = params as any;
+
+  // Multi-image to video (kling-v1-6 or multiple images)
+  if (p.imageUrls && Array.isArray(p.imageUrls) && p.imageUrls.length > 1) {
+    return '/v1/videos/multi-image2video';
+  }
+
+  // Image to video with first-last frame
+  if (imageUrl && endImageUrl) {
+    return '/v1/videos/image2video';
+  }
+
+  // Image to video with single image
+  if (imageUrl && !endImageUrl) {
+    // kling-v2-6 and later support image2video endpoint
+    if (model.includes('v2') || model.includes('v3')) {
+      return '/v1/videos/image2video';
+    }
+    // Fallback to multi-image2video for single image
+    return '/v1/videos/multi-image2video';
+  }
+
+  // Default: text to video
+  return '/v1/videos/text2video';
+}
+
+/**
+ * Build request body based on endpoint type
+ */
+function buildRequestBody(
+  model: string,
+  options: {
+    prompt: string;
+    imageUrl?: string | null;
+    endImageUrl?: string | null;
+    aspectRatio?: string;
+    duration?: number;
+    params: any;
+  },
+): Record<string, unknown> {
+  const { prompt, imageUrl, endImageUrl, aspectRatio, duration, params } = options;
+  const p = params as any;
+
+  const endpoint = determineEndpoint(model, { imageUrl, endImageUrl, params });
+
+  // Common fields for all endpoints
+  const commonBody: Record<string, unknown> = {
+    model_name: model || 'kling-v2-6',
+    prompt,
+  };
+
+  // Add mode and duration if provided
+  if (p.mode) commonBody.mode = p.mode;
+  if (duration !== undefined) commonBody.duration = String(duration);
+  if (aspectRatio !== undefined) commonBody.aspect_ratio = aspectRatio;
+  if (p.negativePrompt) commonBody.negative_prompt = p.negativePrompt;
+  if (p.sound !== undefined) commonBody.sound = p.sound;
+
+  // Endpoint-specific fields
+  switch (endpoint) {
+    case '/v1/videos/text2video': {
+      // Text to video: no image fields needed
+      return commonBody;
+    }
+
+    case '/v1/videos/image2video': {
+      // Image to video (first-last frame)
+      return {
+        ...commonBody,
+        image: imageUrl,
+        ...(endImageUrl && { image_tail: endImageUrl }),
+      };
+    }
+
+    case '/v1/videos/multi-image2video': {
+      // Multi-image to video
+      const imageList: Array<{ image: string }> = [];
+
+      // Handle imageUrls array if provided
+      if (p.imageUrls && Array.isArray(p.imageUrls)) {
+        for (const url of p.imageUrls) {
+          if (url) imageList.push({ image: url });
+        }
+      } else if (imageUrl) {
+        // Fallback to single image
+        imageList.push({ image: imageUrl });
+        if (endImageUrl) {
+          imageList.push({ image: endImageUrl });
+        }
+      }
+
+      return {
+        ...commonBody,
+        image_list: imageList,
+      };
+    }
+
+    default: {
+      return commonBody;
+    }
+  }
+}

--- a/packages/model-runtime/src/providers/keling/video/handleCreateVideoWebhook.ts
+++ b/packages/model-runtime/src/providers/keling/video/handleCreateVideoWebhook.ts
@@ -1,0 +1,85 @@
+import createDebug from 'debug';
+
+import type {
+  HandleCreateVideoWebhookPayload,
+  HandleCreateVideoWebhookResult,
+} from '../../../types/video';
+
+const log = createDebug('lobe-video:keling:webhook');
+
+interface KelingVideoWebhookBody {
+  code?: number;
+  data?: {
+    task_id?: string;
+    task_status?: string;
+    task_status_msg?: string;
+    task_result?: {
+      videos?: Array<{
+        id?: string;
+        url?: string;
+        duration?: string;
+      }>;
+      images?: Array<{
+        index?: number;
+        url?: string;
+      }>;
+    };
+    final_unit_deduction?: string;
+    watermark_info?: {
+      enabled?: boolean;
+    };
+    task_info?: {
+      external_task_id?: string;
+    };
+    created_at?: number;
+    updated_at?: number;
+  };
+  message?: string;
+  request_id?: string;
+}
+
+export async function handleKelingVideoWebhook(
+  payload: HandleCreateVideoWebhookPayload,
+): Promise<HandleCreateVideoWebhookResult> {
+  const body = payload.body as KelingVideoWebhookBody;
+
+  log('Received Keling video webhook: %O', body);
+
+  const taskStatus = body.data?.task_status;
+
+  if (taskStatus === 'submitted' || taskStatus === 'processing') {
+    log('Skipping intermediate status: %s', taskStatus);
+    return { status: 'pending' };
+  }
+
+  const inferenceId = body.data?.task_id;
+  if (!inferenceId) {
+    throw new Error('Missing task_id in webhook body');
+  }
+
+  if (taskStatus === 'succeed') {
+    const videos = body.data?.task_result?.videos;
+    if (!videos || videos.length === 0) {
+      throw new Error('Missing videos in succeeded webhook body');
+    }
+
+    const videoUrl = videos[0].url;
+    if (!videoUrl) {
+      throw new Error('Missing video_url in succeeded webhook body');
+    }
+
+    log('Video generation succeeded: %s, videoUrl: %s', inferenceId, videoUrl);
+
+    return {
+      inferenceId,
+      status: 'success' as const,
+      videoUrl,
+    };
+  }
+
+  const errorMessage = body.data?.task_status_msg || body.message || 'Video generation failed';
+
+  log('Video generation failed: %s, error: %s', inferenceId, errorMessage);
+
+  return { error: errorMessage, inferenceId, status: 'error' };
+}

--- a/packages/model-runtime/src/runtimeMap.ts
+++ b/packages/model-runtime/src/runtimeMap.ts
@@ -28,6 +28,7 @@ import { LobeHunyuanAI } from './providers/hunyuan';
 import { LobeInfiniAI } from './providers/infiniai';
 import { LobeInternLMAI } from './providers/internlm';
 import { LobeJinaAI } from './providers/jina';
+import { LobeKelingAI } from './providers/keling';
 import { LobeLMStudioAI } from './providers/lmstudio';
 import { LobeHubAI } from './providers/lobehub';
 import { LobeLongCatAI } from './providers/longcat';
@@ -102,6 +103,7 @@ export const providerRuntimeMap = {
   infiniai: LobeInfiniAI,
   internlm: LobeInternLMAI,
   jina: LobeJinaAI,
+  keling: LobeKelingAI,
   lmstudio: LobeLMStudioAI,
   lobehub: LobeHubAI,
   longcat: LobeLongCatAI,

--- a/packages/types/src/auth.ts
+++ b/packages/types/src/auth.ts
@@ -34,8 +34,12 @@ export interface ClientSecretPayload {
    */
   oauthAccessToken?: string;
   password?: string;
-
   runtimeProvider?: string;
+
+  /**
+   * Keling specific authentication fields
+   */
+  secretKey?: string;
   /**
    * user id
    * in client db mode it's a uuid

--- a/packages/types/src/user/settings/keyVaults.ts
+++ b/packages/types/src/user/settings/keyVaults.ts
@@ -72,3 +72,9 @@ export interface SearchEngineKeyVaults {
 export interface UserKeyVaults extends SearchEngineKeyVaults {
   search1api?: OpenAICompatibleKeyVault;
 }
+
+export interface KelingKeyVault {
+  apiKey?: string;
+  baseURL?: string;
+  secretKey?: string;
+}

--- a/src/envs/llm.ts
+++ b/src/envs/llm.ts
@@ -169,6 +169,11 @@ export const getLLMConfig = () => {
       ENABLED_INFINIAI: z.boolean(),
       INFINIAI_API_KEY: z.string().optional(),
 
+      ENABLED_KELING: z.boolean(),
+      KELING_PROXY_URL: z.string().optional(),
+      KELING_ACCESS_KEY: z.string().optional(),
+      KELING_SECRET_KEY: z.string().optional(),
+
       ENABLED_FAL: z.boolean(),
       FAL_API_KEY: z.string().optional(),
 
@@ -388,6 +393,11 @@ export const getLLMConfig = () => {
 
       ENABLED_INFINIAI: !!process.env.INFINIAI_API_KEY,
       INFINIAI_API_KEY: process.env.INFINIAI_API_KEY,
+
+      ENABLED_KELING: !!process.env.KELING_ACCESS_KEY && !!process.env.KELING_SECRET_KEY,
+      KELING_PROXY_URL: process.env.KELING_PROXY_URL,
+      KELING_ACCESS_KEY: process.env.KELING_ACCESS_KEY,
+      KELING_SECRET_KEY: process.env.KELING_SECRET_KEY,
 
       ENABLED_FAL: process.env.ENABLED_FAL !== '0',
       FAL_API_KEY: process.env.FAL_API_KEY,

--- a/src/locales/default/modelProvider.ts
+++ b/src/locales/default/modelProvider.ts
@@ -47,6 +47,21 @@ export default {
   'bedrock.unlock.imageGenerationDescription':
     'Enter your AWS AccessKeyId / SecretAccessKey to start generating. The application will not store your authentication credentials.',
   'bedrock.unlock.title': 'Use Custom Bedrock Authentication Information',
+  'keling.accessKey.desc': 'Enter Keling Access Key',
+  'keling.accessKey.placeholder': 'Keling Access Key',
+  'keling.accessKey.title': 'Access Key',
+  'keling.checker.desc': 'Test if Access Key / Secret Key are filled in correctly',
+  'keling.secretKey.desc': 'Enter Keling Secret Key',
+  'keling.secretKey.placeholder': 'Keling Secret Key',
+  'keling.secretKey.title': 'Secret Key',
+  'keling.title': 'Keling',
+  'keling.unlock.description':
+    'Enter your Access Key and Secret Key to start the session. The app will not store your authentication configuration.',
+  'keling.unlock.imageGenerationDescription':
+    'Enter your Access Key and Secret Key to start generating. The application will not store your authentication credentials.',
+  'keling.unlock.title': 'Use Custom Keling Authentication Information',
+  'keling.unlock.accessKey.placeholder': 'Keling Access Key',
+  'keling.unlock.secretKey.placeholder': 'Keling Secret Key',
   'cloudflare.apiKey.desc': 'Please enter Cloudflare API Key',
   'cloudflare.apiKey.placeholder': 'Cloudflare API Key',
   'cloudflare.apiKey.title': 'Cloudflare API Key',

--- a/src/routes/(main)/settings/provider/detail/index.tsx
+++ b/src/routes/(main)/settings/provider/detail/index.tsx
@@ -41,6 +41,10 @@ const Azure = dynamic(() => import('./azure'), {
   loading: () => <Loading debugId="Provider > Azure" />,
   ssr: false,
 });
+const Keling = dynamic(() => import('./keling'), {
+  loading: () => <Loading debugId="Provider > Keling" />,
+  ssr: false,
+});
 const ProviderGrid = dynamic(() => import('../(list)/ProviderGrid'), {
   loading: () => <Loading debugId="Provider > Grid" />,
   ssr: false,
@@ -91,6 +95,9 @@ const ProviderDetailPage = (props: ProviderDetailPageProps) => {
     }
     case 'vertexai': {
       return <VertexAI />;
+    }
+    case 'keling': {
+      return <Keling />;
     }
     default: {
       return <DefaultPage id={id} />;

--- a/src/routes/(main)/settings/provider/detail/keling/index.tsx
+++ b/src/routes/(main)/settings/provider/detail/keling/index.tsx
@@ -1,0 +1,46 @@
+import { InputPassword } from '@lobehub/ui';
+import { cssVar } from 'antd-style';
+import { Image } from 'lucide-react';
+import { ModelProvider } from 'model-bank';
+import { memo } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { FormAction } from '@/features/Conversation/Error/style';
+import { aiProviderSelectors, useAiInfraStore } from '@/store/aiInfra';
+
+const KelingForm = memo<{ description: string }>(({ description }) => {
+  const { t } = useTranslation('modelProvider');
+
+  const config = useAiInfraStore(aiProviderSelectors.providerKeyVaults(ModelProvider.Keling));
+  const setConfig = useAiInfraStore((s) => s.updateAiProviderConfig);
+  const { accessKey, secretKey } = config || {};
+
+  return (
+    <FormAction
+      avatar={<Image color={cssVar.colorText} size={56} />}
+      description={description}
+      title={t('keling.unlock.title')}
+    >
+      <InputPassword
+        autoComplete={'new-password'}
+        placeholder={t('keling.unlock.accessKey.placeholder')}
+        value={accessKey}
+        variant={'filled'}
+        onChange={(e) => {
+          setConfig(ModelProvider.Keling, { keyVaults: { accessKey: e.target.value } });
+        }}
+      />
+      <InputPassword
+        autoComplete={'new-password'}
+        placeholder={t('keling.unlock.secretKey.placeholder')}
+        value={secretKey}
+        variant={'filled'}
+        onChange={(e) => {
+          setConfig(ModelProvider.Keling, { keyVaults: { secretKey: e.target.value } });
+        }}
+      />
+    </FormAction>
+  );
+});
+
+export default KelingForm;

--- a/src/routes/(main)/settings/provider/detail/keling/index.tsx
+++ b/src/routes/(main)/settings/provider/detail/keling/index.tsx
@@ -1,46 +1,61 @@
-import { InputPassword } from '@lobehub/ui';
-import { cssVar } from 'antd-style';
-import { Image } from 'lucide-react';
-import { ModelProvider } from 'model-bank';
-import { memo } from 'react';
+'use client';
+
+import { KelingProviderCard } from 'model-bank/modelProviders';
 import { useTranslation } from 'react-i18next';
 
-import { FormAction } from '@/features/Conversation/Error/style';
+import { FormPassword } from '@/components/FormInput';
+import { SkeletonInput } from '@/components/Skeleton';
 import { aiProviderSelectors, useAiInfraStore } from '@/store/aiInfra';
+import { type GlobalLLMProviderKey } from '@/types/user/settings';
 
-const KelingForm = memo<{ description: string }>(({ description }) => {
+import { KeyVaultsConfigKey } from '../../const';
+import { type ProviderItem } from '../../type';
+import ProviderDetail from '../default';
+
+const providerKey: GlobalLLMProviderKey = 'keling';
+
+const useKelingCard = (): ProviderItem => {
   const { t } = useTranslation('modelProvider');
 
-  const config = useAiInfraStore(aiProviderSelectors.providerKeyVaults(ModelProvider.Keling));
-  const setConfig = useAiInfraStore((s) => s.updateAiProviderConfig);
-  const { accessKey, secretKey } = config || {};
+  const isLoading = useAiInfraStore(aiProviderSelectors.isAiProviderConfigLoading(providerKey));
 
-  return (
-    <FormAction
-      avatar={<Image color={cssVar.colorText} size={56} />}
-      description={description}
-      title={t('keling.unlock.title')}
-    >
-      <InputPassword
-        autoComplete={'new-password'}
-        placeholder={t('keling.unlock.accessKey.placeholder')}
-        value={accessKey}
-        variant={'filled'}
-        onChange={(e) => {
-          setConfig(ModelProvider.Keling, { keyVaults: { accessKey: e.target.value } });
-        }}
-      />
-      <InputPassword
-        autoComplete={'new-password'}
-        placeholder={t('keling.unlock.secretKey.placeholder')}
-        value={secretKey}
-        variant={'filled'}
-        onChange={(e) => {
-          setConfig(ModelProvider.Keling, { keyVaults: { secretKey: e.target.value } });
-        }}
-      />
-    </FormAction>
-  );
-});
+  return {
+    ...KelingProviderCard,
+    apiKeyItems: [
+      {
+        children: isLoading ? (
+          <SkeletonInput />
+        ) : (
+          <FormPassword
+            autoComplete={'new-password'}
+            placeholder={t(`${providerKey}.unlock.accessKey.placeholder`)}
+          />
+        ),
+        desc: t(`${providerKey}.accessKey.desc`),
+        label: t(`${providerKey}.accessKey.title`),
+        name: [KeyVaultsConfigKey, 'apiKey'],
+      },
+      {
+        children: isLoading ? (
+          <SkeletonInput />
+        ) : (
+          <FormPassword
+            autoComplete={'new-password'}
+            placeholder={t(`${providerKey}.unlock.secretKey.placeholder`)}
+          />
+        ),
+        desc: t(`${providerKey}.secretKey.desc`),
+        label: t(`${providerKey}.secretKey.title`),
+        name: [KeyVaultsConfigKey, 'secretKey'],
+      },
+    ],
+  };
+};
 
-export default KelingForm;
+const Page = () => {
+  const card = useKelingCard();
+
+  return <ProviderDetail {...card} />;
+};
+
+export default Page;

--- a/src/server/globalConfig/index.ts
+++ b/src/server/globalConfig/index.ts
@@ -46,6 +46,9 @@ export const getServerGlobalConfig = async () => {
         enabledKey: 'ENABLED_AWS_BEDROCK',
         modelListKey: 'AWS_BEDROCK_MODEL_LIST',
       },
+      keling: {
+        enabledKey: 'ENABLED_KELING',
+      },
       giteeai: {
         enabledKey: 'ENABLED_GITEE_AI',
         modelListKey: 'GITEE_AI_MODEL_LIST',

--- a/src/server/modules/ModelRuntime/index.ts
+++ b/src/server/modules/ModelRuntime/index.ts
@@ -8,6 +8,7 @@ import {
   type CloudflareKeyVault,
   type ComfyUIKeyVault,
   type GithubCopilotKeyVault,
+  type KelingKeyVault,
   type OpenAICompatibleKeyVault,
   type VertexAIKeyVault,
 } from '@lobechat/types';
@@ -33,6 +34,7 @@ type ProviderKeyVaults = OpenAICompatibleKeyVault &
   CloudflareKeyVault &
   ComfyUIKeyVault &
   GithubCopilotKeyVault &
+  KelingKeyVault &
   VertexAIKeyVault;
 
 /**
@@ -141,6 +143,15 @@ export const buildPayloadFromKeyVaults = (
           : undefined,
         oauthAccessToken: keyVaults.oauthAccessToken,
         runtimeProvider,
+      };
+    }
+
+    case ModelProvider.Keling: {
+      return {
+        apiKey: keyVaults.apiKey,
+        baseURL: keyVaults.baseURL,
+        runtimeProvider,
+        secretKey: keyVaults.secretKey,
       };
     }
 

--- a/src/server/modules/ModelRuntime/index.ts
+++ b/src/server/modules/ModelRuntime/index.ts
@@ -208,6 +208,21 @@ const getParamsFromPayload = (provider: string, payload: ClientSecretPayload) =>
       return { apiKey, baseURL };
     }
 
+    case ModelProvider.Keling: {
+      const { KELING_SECRET_KEY, KELING_ACCESS_KEY, KELING_PROXY_URL } = llmConfig;
+      let apiKey: string | undefined = KELING_ACCESS_KEY;
+      let secretKey: string | undefined = KELING_SECRET_KEY;
+      let baseURL: string | undefined = KELING_PROXY_URL;
+
+      if (payload.apiKey) {
+        apiKey = payload.apiKey;
+        secretKey = (payload as any).secretKey;
+        baseURL = payload.baseURL;
+      }
+
+      return { apiKey, baseURL, secretKey };
+    }
+
     case ModelProvider.Bedrock: {
       const { AWS_SECRET_ACCESS_KEY, AWS_ACCESS_KEY_ID, AWS_REGION, AWS_SESSION_TOKEN } = llmConfig;
       let accessKeyId: string | undefined = AWS_ACCESS_KEY_ID;


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

将 Keling 添加为新的图像生成提供方，并将其集成到现有的模型和运行时基础设施中。

新功能：
- 引入 Keling 图像模型（Keling Image O1 和 Keling V2.1），支持可配置参数用于图像生成和编辑。
- 添加一个 Keling 模型提供方卡片，在提供方列表中使用的元数据和设置。
- 实现一个 Keling 运行时客户端，使用 JWT 进行认证，向 Keling API 提交图像生成任务，轮询任务完成状态，并返回生成的图像 URL。

增强内容：
- 将 Keling 提供方接入默认模型列表、提供方枚举、提供方卡片索引以及运行时提供方映射，使其在整个系统中可用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add Keling as a new image-generation provider and integrate it into the existing model and runtime infrastructure.

New Features:
- Introduce Keling image models (Keling Image O1 and Keling V2.1) with configurable parameters for image generation and editing.
- Add a Keling model provider card with metadata and settings for use in the provider list.
- Implement a Keling runtime client that authenticates with JWT, submits image generation tasks to Keling APIs, polls for completion, and returns generated image URLs.

Enhancements:
- Wire the Keling provider into the default model list, provider enums, provider cards index, and runtime provider map so it is available throughout the system.

</details>