### PR TITLE
🐛 fix(github-copilot): switch codex models to responses api

### DIFF
--- a/packages/model-bank/src/modelProviders/githubCopilot.ts
+++ b/packages/model-bank/src/modelProviders/githubCopilot.ts
@@ -19,6 +19,7 @@ const GithubCopilot: ModelProviderCard = {
     sdkType: 'openai',
     showApiKey: false,
     showChecker: true,
+    supportResponsesApi: true,
   },
   url: 'https://github.com/features/copilot',
 };

--- a/packages/model-runtime/src/providers/githubCopilot/index.test.ts
+++ b/packages/model-runtime/src/providers/githubCopilot/index.test.ts
@@ -185,4 +185,64 @@ describe('LobeGithubCopilotAI', () => {
       expect(instance.baseURL).toBe('https://api.githubcopilot.com');
     });
   });
+
+  describe('responses api routing helpers', () => {
+    it('should use responses API for responses-only model', () => {
+      const instance = new LobeGithubCopilotAI({ apiKey: 'ghp_test' });
+
+      const shouldUse = (instance as any).shouldUseResponsesAPI('gpt-5.1-codex-mini');
+
+      expect(shouldUse).toBe(true);
+    });
+
+    it('should respect apiMode override to chatCompletion', () => {
+      const instance = new LobeGithubCopilotAI({ apiKey: 'ghp_test' });
+
+      const shouldUse = (instance as any).shouldUseResponsesAPI(
+        'gpt-5.1-codex-mini',
+        'chatCompletion',
+      );
+
+      expect(shouldUse).toBe(false);
+    });
+
+    it('should respect apiMode override to responses', () => {
+      const instance = new LobeGithubCopilotAI({ apiKey: 'ghp_test' });
+
+      const shouldUse = (instance as any).shouldUseResponsesAPI('gpt-4o', 'responses');
+
+      expect(shouldUse).toBe(true);
+    });
+
+    it('should convert chat completion tool to responses tool', () => {
+      const instance = new LobeGithubCopilotAI({ apiKey: 'ghp_test' });
+      const chatTool = {
+        function: {
+          description: 'Get weather',
+          name: 'get_weather',
+          parameters: {
+            properties: {
+              city: { type: 'string' },
+            },
+            type: 'object',
+          },
+        },
+        type: 'function',
+      };
+
+      const responseTool = (instance as any).convertChatCompletionToolToResponseTool(chatTool);
+
+      expect(responseTool).toEqual({
+        description: 'Get weather',
+        name: 'get_weather',
+        parameters: {
+          properties: {
+            city: { type: 'string' },
+          },
+          type: 'object',
+        },
+        type: 'function',
+      });
+    });
+  });
 });

--- a/packages/model-runtime/src/providers/githubCopilot/index.test.ts
+++ b/packages/model-runtime/src/providers/githubCopilot/index.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment node
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { responsesAPIModels } from '../../const/models';
 import { LobeGithubCopilotAI } from './index';
 
 // Mock console.error to avoid polluting test output
@@ -187,31 +188,12 @@ describe('LobeGithubCopilotAI', () => {
   });
 
   describe('responses api routing helpers', () => {
-    it('should use responses API for responses-only model', () => {
-      const instance = new LobeGithubCopilotAI({ apiKey: 'ghp_test' });
-
-      const shouldUse = (instance as any).shouldUseResponsesAPI('gpt-5.1-codex-mini');
-
-      expect(shouldUse).toBe(true);
+    it('should contain codex mini model in responses api model list', () => {
+      expect(responsesAPIModels.has('gpt-5.1-codex-mini')).toBe(true);
     });
 
-    it('should respect apiMode override to chatCompletion', () => {
-      const instance = new LobeGithubCopilotAI({ apiKey: 'ghp_test' });
-
-      const shouldUse = (instance as any).shouldUseResponsesAPI(
-        'gpt-5.1-codex-mini',
-        'chatCompletion',
-      );
-
-      expect(shouldUse).toBe(false);
-    });
-
-    it('should respect apiMode override to responses', () => {
-      const instance = new LobeGithubCopilotAI({ apiKey: 'ghp_test' });
-
-      const shouldUse = (instance as any).shouldUseResponsesAPI('gpt-4o', 'responses');
-
-      expect(shouldUse).toBe(true);
+    it('should not treat gpt-4o as responses-only model', () => {
+      expect(responsesAPIModels.has('gpt-4o')).toBe(false);
     });
 
     it('should convert chat completion tool to responses tool', () => {

--- a/packages/model-runtime/src/providers/githubCopilot/index.ts
+++ b/packages/model-runtime/src/providers/githubCopilot/index.ts
@@ -2,9 +2,14 @@ import { type ChatModelCard } from '@lobechat/types';
 import { ModelProvider } from 'model-bank';
 import OpenAI from 'openai';
 
+import { responsesAPIModels } from '../../const/models';
 import { type LobeRuntimeAI } from '../../core/BaseAI';
-import { pruneReasoningPayload } from '../../core/contextBuilders/openai';
-import { OpenAIStream } from '../../core/streams';
+import {
+  convertOpenAIResponseInputs,
+  pruneReasoningPayload,
+} from '../../core/contextBuilders/openai';
+import { transformResponseAPIToStream } from '../../core/openaiCompatibleFactory';
+import { OpenAIResponsesStream, OpenAIStream } from '../../core/streams';
 import { type ChatMethodOptions, type ChatStreamPayload } from '../../types';
 import { AgentRuntimeErrorType } from '../../types/error';
 import { AgentRuntimeError } from '../../utils/createError';
@@ -167,8 +172,52 @@ export class LobeGithubCopilotAI implements LobeRuntimeAI {
       const { model, ...rest } = this.handlePayload(payload);
       const shouldStream = rest.stream !== false;
 
+      if (this.shouldUseResponsesAPI(model, (payload as any).apiMode)) {
+        const input = await convertOpenAIResponseInputs(rest.messages as any, {
+          strictToolPairing: true,
+        });
+
+        const responseTools = rest.tools?.map(this.convertChatCompletionToolToResponseTool);
+        const response = await client.responses.create(
+          {
+            input,
+            model,
+            stream: shouldStream,
+            ...(responseTools ? { tools: responseTools } : {}),
+          },
+          { signal: options?.signal },
+        );
+
+        if (shouldStream) {
+          return StreamingResponse(
+            OpenAIResponsesStream(response as any, {
+              callbacks: options?.callback,
+              payload: { model, provider: ModelProvider.GithubCopilot },
+            }),
+            { headers: options?.headers },
+          );
+        }
+
+        const responseStream = transformResponseAPIToStream(response as OpenAI.Responses.Response);
+
+        return StreamingResponse(
+          OpenAIResponsesStream(responseStream, {
+            callbacks: options?.callback,
+            enableStreaming: false,
+            payload: { model, provider: ModelProvider.GithubCopilot },
+          }),
+          { headers: options?.headers },
+        );
+      }
+
+      const { apiMode: _, ...cleanedRest } = rest as any;
+
       const response = await client.chat.completions.create(
-        { ...rest, model, stream: shouldStream } as OpenAI.ChatCompletionCreateParamsStreaming,
+        {
+          ...cleanedRest,
+          model,
+          stream: shouldStream,
+        } as OpenAI.ChatCompletionCreateParamsStreaming,
         { signal: options?.signal },
       );
 
@@ -223,6 +272,16 @@ export class LobeGithubCopilotAI implements LobeRuntimeAI {
 
     return { ...payload, stream: true };
   }
+
+  private shouldUseResponsesAPI(model: string, apiMode?: string): boolean {
+    if (apiMode === 'chatCompletion') return false;
+    if (apiMode === 'responses') return true;
+    return responsesAPIModels.has(model);
+  }
+
+  private convertChatCompletionToolToResponseTool = (tool: any): OpenAI.Responses.Tool => {
+    return { type: tool.type, ...tool.function } as any;
+  };
 
   private async executeWithRetry<T>(fn: () => Promise<T>): Promise<T> {
     let totalAttempts = 0;

--- a/packages/model-runtime/src/providers/githubCopilot/index.ts
+++ b/packages/model-runtime/src/providers/githubCopilot/index.ts
@@ -172,7 +172,7 @@ export class LobeGithubCopilotAI implements LobeRuntimeAI {
       const { model, ...rest } = this.handlePayload(payload);
       const shouldStream = rest.stream !== false;
 
-      if (this.shouldUseResponsesAPI(model, (payload as any).apiMode)) {
+      if (responsesAPIModels.has(model) || (payload as any).apiMode === 'responses') {
         const input = await convertOpenAIResponseInputs(rest.messages as any, {
           strictToolPairing: true,
         });
@@ -271,12 +271,6 @@ export class LobeGithubCopilotAI implements LobeRuntimeAI {
     }
 
     return { ...payload, stream: true };
-  }
-
-  private shouldUseResponsesAPI(model: string, apiMode?: string): boolean {
-    if (apiMode === 'chatCompletion') return false;
-    if (apiMode === 'responses') return true;
-    return responsesAPIModels.has(model);
   }
 
   private convertChatCompletionToolToResponseTool = (tool: any): OpenAI.Responses.Tool => {


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

通过 Responses API 路由 GitHub Copilot Codex 模型，同时保持与聊天补全的兼容性以及流式行为。

增强内容：
- 添加条件路由逻辑：对受支持的 GitHub Copilot 模型使用 Responses API，并提供显式的 `apiMode` 覆盖，以在 chat 与 responses 模式之间切换。
- 在调用 Responses API 时，将 OpenAI chat-completion 工具转换为 Responses API 的工具格式。
- 在模型库中将 GitHub Copilot 模型提供方标记为支持 Responses API。

测试：
- 添加单元测试，覆盖 GitHub Copilot 提供方在 Responses API 路由决策和工具转换行为方面的逻辑。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Route GitHub Copilot codex models through the Responses API while preserving chat completion compatibility and streaming behavior.

Enhancements:
- Add conditional routing to use the Responses API for supported GitHub Copilot models, with an explicit apiMode override for chat vs responses.
- Introduce conversion of OpenAI chat-completion tools into Responses API tool format when calling the Responses API.
- Mark the GitHub Copilot model provider as supporting the Responses API in the model bank.

Tests:
- Add unit tests covering Responses API routing decisions and tool conversion behavior for the GitHub Copilot provider.

</details>