### PR TITLE
💄 style: add LongCat-Flash-Omni-2603 support

### DIFF
--- a/packages/model-bank/src/aiModels/longcat.ts
+++ b/packages/model-bank/src/aiModels/longcat.ts
@@ -27,10 +27,10 @@ const longcatModels: AIChatModelCard[] = [
     },
     contextWindowTokens: 262_144,
     description:
-      'The LongCat-Flash-Thinking-2601 model has been officially released. As an upgraded reasoning model built on a Mixture-of-Experts (MoE) architecture, it features a total of 560 billion parameters. While maintaining strong competitiveness across traditional reasoning benchmarks, it systematically enhances Agent-level reasoning capabilities through large-scale multi-environment reinforcement learning. Compared to the LongCat-Flash-Thinking model, the key upgrades are as follows: Extreme Robustness in Noisy Environments: Through systematic curriculum-style training targeting noise and uncertainty in real-world settings, the model demonstrates outstanding performance in Agent tool invocation, Agent-based search, and tool-integrated reasoning, with significantly improved generalization. Powerful Agent Capabilities: By constructing a tightly coupled dependency graph encompassing more than 60 tools, and scaling training through multi-environment expansion and large-scale exploratory learning, the model markedly improves its ability to generalize to complex and out-of-distribution real-world scenarios. Advanced Deep Thinking Mode: It expands the breadth of reasoning via parallel inference and deepens analytical capability through recursive feedback-driven summarization and abstraction mechanisms, effectively addressing highly challenging problems.',
-    displayName: 'LongCat-Flash-Thinking-2601',
+      'To ensure you receive top-tier reasoning performance, the LongCat API platform has unified and upgraded access to the LongCat-Flash-Thinking model. All requests using `model=LongCat-Flash-Thinking` will be automatically routed to the latest version, `LongCat-Flash-Thinking-2601`, without requiring any code changes.',
+    displayName: 'LongCat-Flash-Thinking',
     enabled: true,
-    id: 'LongCat-Flash-Thinking-2601',
+    id: 'LongCat-Flash-Thinking',
     pricing: {
       units: [
         { name: 'textInput', rate: 0, strategy: 'fixed', unit: 'millionTokens' },
@@ -47,16 +47,16 @@ const longcatModels: AIChatModelCard[] = [
     },
     contextWindowTokens: 262_144,
     description:
-      'LongCat-Flash-Thinking has been officially released and open-sourced simultaneously. It is a deep reasoning model that can be used for free conversations within LongCat Chat, or accessed via API by specifying model=LongCat-Flash-Thinking.',
-    displayName: 'LongCat-Flash-Thinking',
-    id: 'LongCat-Flash-Thinking',
+      'The LongCat-Flash-Thinking-2601 model has been officially released. As an upgraded reasoning model built on a Mixture-of-Experts (MoE) architecture, it features a total of 560 billion parameters. While maintaining strong competitiveness across traditional reasoning benchmarks, it systematically enhances Agent-level reasoning capabilities through large-scale multi-environment reinforcement learning. Compared to the LongCat-Flash-Thinking model, the key upgrades are as follows: Extreme Robustness in Noisy Environments: Through systematic curriculum-style training targeting noise and uncertainty in real-world settings, the model demonstrates outstanding performance in Agent tool invocation, Agent-based search, and tool-integrated reasoning, with significantly improved generalization. Powerful Agent Capabilities: By constructing a tightly coupled dependency graph encompassing more than 60 tools, and scaling training through multi-environment expansion and large-scale exploratory learning, the model markedly improves its ability to generalize to complex and out-of-distribution real-world scenarios. Advanced Deep Thinking Mode: It expands the breadth of reasoning via parallel inference and deepens analytical capability through recursive feedback-driven summarization and abstraction mechanisms, effectively addressing highly challenging problems.',
+    displayName: 'LongCat-Flash-Thinking-2601',
+    id: 'LongCat-Flash-Thinking-2601',
     pricing: {
       units: [
         { name: 'textInput', rate: 0, strategy: 'fixed', unit: 'millionTokens' },
         { name: 'textOutput', rate: 0, strategy: 'fixed', unit: 'millionTokens' },
       ],
     },
-    releasedAt: '2025-09-22',
+    releasedAt: '2026-01-14',
     type: 'chat',
   },
   {
@@ -76,6 +76,28 @@ const longcatModels: AIChatModelCard[] = [
       ],
     },
     releasedAt: '2025-12-12',
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+      vision: true,
+      video: true,
+    },
+    contextWindowTokens: 8192,
+    description:
+      'LongCat-Flash-Omni-2603 has been officially released. As an upgraded version of LongCat-Flash-Omni, it is an end-to-end Omni interaction model with more human-like responses and significantly enhanced multimodal perception capabilities. It is available for free conversations in LongCat Chat, and can also be accessed via API by specifying `model=LongCat-Flash-Omni-2603`. Compared to the LongCat-Flash-Omni model, the core features of LongCat-Flash-Omni-2603 include: Deeper semantic alignment and personalized style adaptation, delivering a more natural and fluent conversational experience. Comprehensive improvements in accuracy across multimodal tasks, including vision, speech, and text. Significantly enhanced performance in problem-solving, emotional understanding, and everyday entertainment scenarios. Native support for voice-based Function Calling, enabling direct parsing of audio instructions and near-zero latency real-time interaction.',
+    displayName: 'LongCat-Flash-Omni-2603',
+    enabled: true,
+    id: 'LongCat-Flash-Omni-2603',
+    pricing: {
+      units: [
+        { name: 'textInput', rate: 0, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 0, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    releasedAt: '2026-03-11',
     type: 'chat',
   },
 ];

--- a/packages/model-runtime/src/providers/longcat/index.ts
+++ b/packages/model-runtime/src/providers/longcat/index.ts
@@ -1,14 +1,28 @@
 import { ModelProvider } from 'model-bank';
 
 import { createOpenAICompatibleRuntime } from '../../core/openaiCompatibleFactory';
+import { parseDataUri } from '../../utils/uriParser';
 
 export const LobeLongCatAI = createOpenAICompatibleRuntime({
   baseURL: 'https://api.longcat.chat/openai/v1',
   chatCompletion: {
     handlePayload: (payload) => {
-      const { frequency_penalty, presence_penalty, ...rest } = payload;
+      const { frequency_penalty, messages, model, presence_penalty, ...rest } = payload;
 
-      const messages = payload.messages?.map((message: any) => {
+      const omniMessages = messages?.map((message: any) => {
+        // If content is a string, convert to LongCat array format
+        if (typeof message?.content === 'string') {
+          return {
+            ...message,
+            content: [
+              {
+                text: message.content,
+                type: 'text',
+              },
+            ],
+          };
+        }
+
         if (!Array.isArray(message?.content)) return message;
 
         return {
@@ -26,12 +40,12 @@ export const LobeLongCatAI = createOpenAICompatibleRuntime({
 
               if (!imageUrl) return item;
 
-              const isUrl = imageUrl.startsWith('http');
+              const { type } = parseDataUri(imageUrl);
 
               return {
                 input_image: {
-                  data: isUrl ? [imageUrl] : imageUrl,
-                  type: isUrl ? 'url' : 'base64',
+                  data: type === 'url' ? [imageUrl] : imageUrl,
+                  type: type === 'url' ? 'url' : 'base64',
                 },
                 type: 'input_image',
               };
@@ -42,12 +56,12 @@ export const LobeLongCatAI = createOpenAICompatibleRuntime({
 
               if (!videoUrl) return item;
 
-              const isUrl = videoUrl.startsWith('http');
+              const { type } = parseDataUri(videoUrl);
 
               return {
                 input_video: {
                   data: videoUrl,
-                  type: isUrl ? 'url' : 'base64',
+                  type: type === 'url' ? 'url' : 'base64',
                 },
                 type: 'input_video',
               };
@@ -61,10 +75,11 @@ export const LobeLongCatAI = createOpenAICompatibleRuntime({
       return {
         ...rest,
         frequency_penalty: undefined,
-        messages,
+        model,
         presence_penalty: undefined,
-        // if payload.model contains omni, then add output_modalities and stream
-        ...(payload.model.includes('omni') ? { output_modalities: ['text'], stream: false } : {}),
+        ...(model.includes('omni')
+          ? { messages: omniMessages, output_modalities: ['text'], stream: false }
+          : { messages, stream: true }),
       } as any;
     },
   },

--- a/packages/model-runtime/src/providers/longcat/index.ts
+++ b/packages/model-runtime/src/providers/longcat/index.ts
@@ -8,11 +8,63 @@ export const LobeLongCatAI = createOpenAICompatibleRuntime({
     handlePayload: (payload) => {
       const { frequency_penalty, presence_penalty, ...rest } = payload;
 
+      const messages = payload.messages?.map((message: any) => {
+        if (!Array.isArray(message?.content)) return message;
+
+        return {
+          ...message,
+          content: message.content.map((item: any) => {
+            if (item?.type === 'text') {
+              return {
+                text: item.text ?? '',
+                type: 'text',
+              };
+            }
+
+            if (item?.type === 'image_url') {
+              const imageUrl = item.image_url?.url;
+
+              if (!imageUrl) return item;
+
+              const isUrl = imageUrl.startsWith('http');
+
+              return {
+                input_image: {
+                  data: isUrl ? [imageUrl] : imageUrl,
+                  type: isUrl ? 'url' : 'base64',
+                },
+                type: 'input_image',
+              };
+            }
+
+            if (item?.type === 'video_url') {
+              const videoUrl = item.video_url?.url;
+
+              if (!videoUrl) return item;
+
+              const isUrl = videoUrl.startsWith('http');
+
+              return {
+                input_video: {
+                  data: videoUrl,
+                  type: isUrl ? 'url' : 'base64',
+                },
+                type: 'input_video',
+              };
+            }
+
+            return item;
+          }),
+        };
+      });
+
       return {
         ...rest,
         frequency_penalty: undefined,
+        messages,
         presence_penalty: undefined,
-        stream: true,
+        // if payload.model contains omni, then add output_modalities and stream
+        ...(payload.model.includes('omni') ? { output_modalities: ['text'], stream: false } : {}),
       } as any;
     },
   },


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

为 LongCat-Flash-Omni-2603 多模态模型添加支持，并调整 LongCat 模型元数据和负载处理逻辑，以适配 omni 和多模态请求。

新功能：
- 在模型库中注册具有多模态和函数调用能力的 LongCat-Flash-Omni-2603 对话模型。

增强与改进：
- 规范 LongCat 提供方的消息格式，以支持文本、图像和视频输入，并将其映射为提供方特定的多模态格式。
- 在使用 omni LongCat 模型时，自动配置输出模态和流式输出行为。
- 更新 LongCat-Flash-Thinking 和 LongCat-Flash-Thinking-2601 的模型标识符和描述，以反映最新的路由与发布信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for the LongCat-Flash-Omni-2603 multimodal model and adjust LongCat model metadata and payload handling for omni and multimodal requests.

New Features:
- Register the LongCat-Flash-Omni-2603 chat model with multimodal and function-calling capabilities in the model bank.

Enhancements:
- Normalize LongCat provider messages to support text, image, and video inputs and map them into the provider-specific multimodal format.
- Automatically configure output modalities and streaming behavior when using omni LongCat models.
- Update LongCat-Flash-Thinking and LongCat-Flash-Thinking-2601 model identifiers and descriptions to reflect the latest routing and release information.

</details>