### PR TITLE
💄 style: add wanxiang2.7 & keling ImageGen from Qwen

### DIFF
--- a/packages/model-bank/src/aiModels/qwen.ts
+++ b/packages/model-bank/src/aiModels/qwen.ts
@@ -3109,6 +3109,54 @@ const qwenImageModels: AIImageModelCard[] = [
     type: 'image',
   },
   {
+    description: 'Wanxiang 2.7 Image Professional Edition, supports 4K high-definition output.',
+    displayName: 'Wanxiang2.7 Image Pro',
+    enabled: true,
+    id: 'wan2.7-image-pro',
+    organization: 'Qwen',
+    parameters: {
+      height: { default: 2048, max: 11_585, min: 271, step: 1 },
+      imageUrls: {
+        default: [],
+      },
+      prompt: {
+        default: '',
+      },
+      seed: { default: null },
+      width: { default: 2048, max: 11_585, min: 271, step: 1 },
+    },
+    pricing: {
+      currency: 'CNY',
+      units: [{ name: 'imageGeneration', rate: 0.5, strategy: 'fixed', unit: 'image' }],
+    },
+    releasedAt: '2026-04-01',
+    type: 'image',
+  },
+  {
+    description: 'Wanxiang 2.7 Image, faster image generation speed.',
+    displayName: 'Wanxiang2.7 Image',
+    enabled: true,
+    id: 'wan2.7-image',
+    organization: 'Qwen',
+    parameters: {
+      height: { default: 2048, max: 5792, min: 271, step: 1 },
+      imageUrls: {
+        default: [],
+      },
+      prompt: {
+        default: '',
+      },
+      seed: { default: null },
+      width: { default: 2048, max: 5792, min: 271, step: 1 },
+    },
+    pricing: {
+      currency: 'CNY',
+      units: [{ name: 'imageGeneration', rate: 0.2, strategy: 'fixed', unit: 'image' }],
+    },
+    releasedAt: '2026-04-01',
+    type: 'image',
+  },
+  {
     description: 'Wanxiang 2.6 Image supports image editing and mixed image–text layout output.',
     displayName: 'Wanxiang2.6 Image',
     enabled: true,

--- a/packages/model-bank/src/aiModels/qwen.ts
+++ b/packages/model-bank/src/aiModels/qwen.ts
@@ -3373,6 +3373,66 @@ const qwenImageModels: AIImageModelCard[] = [
   },
   {
     description:
+      'Supports up to 10 reference images, allowing you to lock subjects, elements, and color tones to ensure consistent style. Combines style transfer, portrait/character referencing, multi-image fusion, and localized inpainting for flexible control. Delivers realistic portrait details, with overall visuals that are delicate and richly layered, featuring cinematic color and atmosphere.',
+    displayName: 'Kling V3 Image Generation',
+    enabled: true,
+    id: 'kling/kling-v3-image-generation',
+    organization: 'Qwen',
+    parameters: {
+      aspectRatio: {
+        default: '16:9',
+        enum: ['16:9', '9:16', '1:1'],
+      },
+      imageUrl: {
+        default: '',
+      },
+      prompt: {
+        default: '',
+      },
+      resolution: {
+        default: '1k',
+        enum: ['1k', '2k'],
+      },
+    },
+    pricing: {
+      currency: 'CNY',
+      units: [{ name: 'imageGeneration', rate: 0.2, strategy: 'fixed', unit: 'image' }],
+    },
+    releasedAt: '2026-03-26',
+    type: 'image',
+  },
+  {
+    description:
+      'Unlock cinematic storytelling visuals with new series image generation and direct 2K/4K output. Deeply analyzes audiovisual elements in prompts to precisely execute creative instructions. Supports flexible multi-reference inputs and comprehensive quality upgrades, ideal for storyboards, narrative concept art, and scene design.',
+    displayName: 'Kling V3 Omni Image Generation',
+    enabled: true,
+    id: 'kling/kling-v3-omni-image-generation',
+    organization: 'Qwen',
+    parameters: {
+      aspectRatio: {
+        default: '16:9',
+        enum: ['16:9', '9:16', '1:1'],
+      },
+      imageUrls: {
+        default: [],
+      },
+      prompt: {
+        default: '',
+      },
+      resolution: {
+        default: '1k',
+        enum: ['1k', '2k', '4k'],
+      },
+    },
+    pricing: {
+      currency: 'CNY',
+      units: [{ name: 'imageGeneration', rate: 0.2, strategy: 'fixed', unit: 'image' }],
+    },
+    releasedAt: '2026-03-26',
+    type: 'image',
+  },
+  {
+    description:
       'FLUX.1 [schnell] is the most advanced open-source few-step model, surpassing similar competitors and even strong non-distilled models like Midjourney v6.0 and DALL-E 3 (HD). It is finely tuned to preserve pretraining diversity, significantly improving visual quality, instruction following, size/aspect variation, font handling, and output diversity.',
     displayName: 'FLUX.1 [schnell]',
     id: 'flux-schnell',

--- a/packages/model-runtime/src/providers/qwen/createImage.test.ts
+++ b/packages/model-runtime/src/providers/qwen/createImage.test.ts
@@ -757,7 +757,7 @@ describe('createQwenImage', () => {
           ],
         },
         model: 'qwen-image-edit',
-        parameters: {},
+        parameters: { n: 1 },
       });
     });
 
@@ -817,6 +817,143 @@ describe('createQwenImage', () => {
         expect.objectContaining({
           errorType: 'ProviderBizError',
           provider: 'qwen',
+        }),
+      );
+    });
+  });
+
+  describe('new image-generation route coverage', () => {
+    it('should use image-generation async API for kling model and parse choices result', async () => {
+      const mockTaskId = 'task-kling-123';
+      const mockImageUrl = 'https://p4-fdl.klingai.com/xxx.png?token=abc';
+
+      global.fetch = vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            output: { task_id: mockTaskId },
+            request_id: 'req-kling-1',
+          }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            output: {
+              choices: [
+                {
+                  message: {
+                    content: [{ image: mockImageUrl, type: 'image' }],
+                  },
+                },
+              ],
+              task_id: mockTaskId,
+              task_status: 'SUCCEEDED',
+            },
+            request_id: 'req-kling-2',
+          }),
+        });
+
+      const payload: CreateImagePayload = {
+        model: 'kling/kling-v3-omni-image-generation',
+        params: {
+          aspectRatio: '1:1',
+          imageUrls: ['https://cdn.example.com/ref-1.png', 'https://cdn.example.com/ref-2.png'],
+          prompt: '参考图1风格和图2背景生成番茄炒蛋',
+          resolution: '1k',
+        },
+      };
+
+      const result = await createQwenImage(payload, mockOptions);
+
+      expect(result).toEqual({ imageUrl: mockImageUrl });
+
+      const [firstUrl, firstOptions] = (fetch as any).mock.calls[0];
+      expect(firstUrl).toBe(
+        'https://dashscope.aliyuncs.com/api/v1/services/aigc/image-generation/generation',
+      );
+      expect(firstOptions).toEqual({
+        body: JSON.stringify({
+          input: {
+            messages: [
+              {
+                content: [
+                  { text: '参考图1风格和图2背景生成番茄炒蛋' },
+                  { image: 'https://cdn.example.com/ref-1.png' },
+                  { image: 'https://cdn.example.com/ref-2.png' },
+                ],
+                role: 'user',
+              },
+            ],
+          },
+          model: 'kling/kling-v3-omni-image-generation',
+          parameters: {
+            n: 1,
+            aspect_ratio: '1:1',
+            resolution: '1k',
+            size: '1024*1024',
+          },
+        }),
+        headers: {
+          'Authorization': 'Bearer test-api-key',
+          'Content-Type': 'application/json',
+          'X-DashScope-Async': 'enable',
+        },
+        method: 'POST',
+      });
+    });
+
+    it('should use multimodal-generation sync API for wan2.7 model', async () => {
+      const mockImageUrl = 'https://dashscope.oss-cn-beijing.aliyuncs.com/aigc/wan27-image.jpg';
+
+      global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          output: {
+            choices: [
+              {
+                message: {
+                  content: [{ image: mockImageUrl }],
+                },
+              },
+            ],
+          },
+          request_id: 'req-wan27-1',
+        }),
+      });
+
+      const payload: CreateImagePayload = {
+        model: 'wan2.7-image-pro',
+        params: {
+          height: 2048,
+          prompt: 'A futuristic city skyline',
+          seed: 123,
+          width: 2048,
+        },
+      };
+
+      const result = await createQwenImage(payload, mockOptions);
+
+      expect(result).toEqual({ imageUrl: mockImageUrl });
+
+      expect(fetch).toHaveBeenCalledWith(
+        'https://dashscope.aliyuncs.com/api/v1/services/aigc/multimodal-generation/generation',
+        expect.objectContaining({
+          body: JSON.stringify({
+            input: {
+              messages: [
+                {
+                  content: [{ text: 'A futuristic city skyline' }],
+                  role: 'user',
+                },
+              ],
+            },
+            model: 'wan2.7-image-pro',
+            parameters: {
+              n: 1,
+              seed: 123,
+            },
+          }),
         }),
       );
     });

--- a/packages/model-runtime/src/providers/qwen/createImage.test.ts
+++ b/packages/model-runtime/src/providers/qwen/createImage.test.ts
@@ -903,24 +903,30 @@ describe('createQwenImage', () => {
       });
     });
 
-    it('should use multimodal-generation sync API for wan2.7 model', async () => {
+    it('should use image-generation async API for wan2.7 model', async () => {
+      const mockTaskId = 'task-wan27-1';
       const mockImageUrl = 'https://dashscope.oss-cn-beijing.aliyuncs.com/aigc/wan27-image.jpg';
 
-      global.fetch = vi.fn().mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          output: {
-            choices: [
-              {
-                message: {
-                  content: [{ image: mockImageUrl }],
-                },
-              },
-            ],
-          },
-          request_id: 'req-wan27-1',
-        }),
-      });
+      global.fetch = vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            output: { task_id: mockTaskId },
+            request_id: 'req-wan27-create',
+          }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            output: {
+              results: [{ url: mockImageUrl }],
+              task_id: mockTaskId,
+              task_status: 'SUCCEEDED',
+            },
+            request_id: 'req-wan27-status',
+          }),
+        });
 
       const payload: CreateImagePayload = {
         model: 'wan2.7-image-pro',
@@ -936,26 +942,89 @@ describe('createQwenImage', () => {
 
       expect(result).toEqual({ imageUrl: mockImageUrl });
 
-      expect(fetch).toHaveBeenCalledWith(
-        'https://dashscope.aliyuncs.com/api/v1/services/aigc/multimodal-generation/generation',
-        expect.objectContaining({
-          body: JSON.stringify({
-            input: {
-              messages: [
-                {
-                  content: [{ text: 'A futuristic city skyline' }],
-                  role: 'user',
-                },
-              ],
-            },
-            model: 'wan2.7-image-pro',
-            parameters: {
-              n: 1,
-              seed: 123,
-            },
-          }),
-        }),
+      const [createUrl, createOptions] = (fetch as any).mock.calls[0];
+
+      expect(createUrl).toBe(
+        'https://dashscope.aliyuncs.com/api/v1/services/aigc/image-generation/generation',
       );
+      expect(JSON.parse(createOptions.body)).toEqual({
+        input: {
+          messages: [
+            {
+              content: [{ text: 'A futuristic city skyline' }],
+              role: 'user',
+            },
+          ],
+        },
+        model: 'wan2.7-image-pro',
+        parameters: {
+          n: 1,
+          seed: 123,
+          size: '2048*2048',
+        },
+      });
+
+      expect(fetch).toHaveBeenCalledWith(
+        `https://dashscope.aliyuncs.com/api/v1/tasks/${mockTaskId}`,
+        {
+          headers: {
+            Authorization: 'Bearer test-api-key',
+          },
+        },
+      );
+    });
+
+    it('should use multimodal-generation sync API for sync-only model', async () => {
+      const mockImageUrl = 'https://dashscope.oss-cn-beijing.aliyuncs.com/aigc/sync-only-image.jpg';
+
+      global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          output: {
+            choices: [
+              {
+                message: {
+                  content: [{ image: mockImageUrl }],
+                },
+              },
+            ],
+          },
+          request_id: 'req-sync-only',
+        }),
+      });
+
+      const payload: CreateImagePayload = {
+        model: 'qwen-image-max',
+        params: {
+          prompt: 'A cinematic portrait',
+          seed: 42,
+        },
+      };
+
+      const result = await createQwenImage(payload, mockOptions);
+
+      expect(result).toEqual({ imageUrl: mockImageUrl });
+
+      const [syncUrl, syncOptions] = (fetch as any).mock.calls[0];
+
+      expect(syncUrl).toBe(
+        'https://dashscope.aliyuncs.com/api/v1/services/aigc/multimodal-generation/generation',
+      );
+      expect(JSON.parse(syncOptions.body)).toEqual({
+        input: {
+          messages: [
+            {
+              content: [{ text: 'A cinematic portrait' }],
+              role: 'user',
+            },
+          ],
+        },
+        model: 'qwen-image-max',
+        parameters: {
+          n: 1,
+          seed: 42,
+        },
+      });
     });
   });
 });

--- a/packages/model-runtime/src/providers/qwen/createImage.ts
+++ b/packages/model-runtime/src/providers/qwen/createImage.ts
@@ -12,13 +12,14 @@ const text2ImageModels = [
   /^wan2\.(2|5)-t2i-/,
   /^wanx2\.(0|1)-t2i-/,
   /^wanx-v1/,
+  /^qwen-image(-plus)?$/,
   /^stable-diffusion-/,
   /^flux-/,
 ];
 
 const image2ImageModels = [/^wan2\.(2|5)-i2i-/];
 
-const asyncOnlyModels = [/^kling/];
+const syncOnlyModels = [/^qwen-image-(edit|max)/, /^qwen-image-2\.0/, /^z-image-turbo/];
 
 const imageRequiredModels = [/^qwen-image-edit/, /^wan2\.(2|5)-i2i-/, /^wan2\.6-image/];
 
@@ -406,7 +407,7 @@ export async function createQwenImage(
   try {
     const isText2Image = matchesModel(model, text2ImageModels);
     const isImage2Image = matchesModel(model, image2ImageModels);
-    const isAsyncGeneration = matchesModel(model, asyncOnlyModels);
+    const isSyncGeneration = matchesModel(model, syncOnlyModels);
 
     if (isText2Image || isImage2Image) {
       const endpoint = isImage2Image ? 'image2image' : 'text2image';
@@ -423,16 +424,16 @@ export async function createQwenImage(
       return await pollTaskToImageResponse(taskId, apiKey, dashscopeURL, model);
     }
 
-    if (isAsyncGeneration) {
-      log('Using image-generation async API for model: %s', model);
-
-      const taskId = await createHTTPAsyncGenerationTask(payload, apiKey, dashscopeURL);
-
-      return await pollTaskToImageResponse(taskId, apiKey, dashscopeURL, model);
+    if (isSyncGeneration) {
+      log('Using multimodal-generation API for model: %s', model);
+      return await createHTTPSyncGeneration(payload, apiKey, dashscopeURL);
     }
 
-    log('Using multimodal-generation API for model: %s', model);
-    return await createHTTPSyncGeneration(payload, apiKey, dashscopeURL);
+    log('Using image-generation async API for model: %s', model);
+
+    const taskId = await createHTTPAsyncGenerationTask(payload, apiKey, dashscopeURL);
+
+    return await pollTaskToImageResponse(taskId, apiKey, dashscopeURL, model);
   } catch (error) {
     log('Error in createQwenImage: %O', error);
 

--- a/packages/model-runtime/src/providers/qwen/createImage.ts
+++ b/packages/model-runtime/src/providers/qwen/createImage.ts
@@ -18,7 +18,7 @@ const text2ImageModels = [
 
 const image2ImageModels = [/^wan2\.(2|5)-i2i-/];
 
-const asyncGenerationModels = [/^wan2\.7-image/, /^kling\/.+-image-generation$/];
+const asyncOnlyModels = [/^kling/];
 
 const imageRequiredModels = [/^qwen-image-edit/, /^wan2\.(2|5)-i2i-/, /^wan2\.6-image/];
 
@@ -50,19 +50,6 @@ interface QwenImageTaskResponse {
   request_id: string;
 }
 
-interface QwenMultimodalGenerationResponse {
-  output: {
-    choices?: Array<{
-      message?: {
-        content?: Array<{
-          image?: string;
-        }>;
-      };
-    }>;
-  };
-  request_id: string;
-}
-
 function extractImageUrlFromTaskResult(taskStatus: QwenImageTaskResponse): string | undefined {
   const generatedImageUrl = taskStatus.output.results?.[0]?.url;
   if (generatedImageUrl) return generatedImageUrl;
@@ -78,7 +65,7 @@ function extractImageUrlFromTaskResult(taskStatus: QwenImageTaskResponse): strin
  * Create an image generation task with Qwen API
  * Supports both text-to-image and image-to-image workflows
  */
-async function createQwenImageTask(
+async function createLegacySynthesisTask(
   payload: CreateImagePayload,
   apiKey: string,
   endpoint: 'text2image' | 'image2image',
@@ -157,7 +144,7 @@ async function createQwenImageTask(
  * Create an async image-generation task with Qwen API
  * Used by newer async models like wan2.7-image and kling image-generation family
  */
-async function createAsyncGenerationTask(
+async function createHTTPAsyncGenerationTask(
   payload: CreateImagePayload,
   apiKey: string,
   baseUrl: string,
@@ -178,21 +165,16 @@ async function createAsyncGenerationTask(
     }
   }
 
-  const optionalParams = params as Record<string, unknown>;
   const parameters: Record<string, unknown> = {
+    n: 1,
+    ...(params.aspectRatio ? { aspect_ratio: params.aspectRatio } : {}),
+    ...(params.resolution ? { resolution: params.resolution } : {}),
     ...(typeof params.seed === 'number' ? { seed: params.seed } : {}),
-    ...(typeof optionalParams.n === 'number' ? { n: optionalParams.n } : {}),
-    ...(typeof optionalParams.resultType === 'string'
-      ? { result_type: optionalParams.resultType }
-      : {}),
-    ...(typeof optionalParams.aspectRatio === 'string'
-      ? { aspect_ratio: optionalParams.aspectRatio }
-      : {}),
-    ...(typeof optionalParams.resolution === 'string'
-      ? { resolution: optionalParams.resolution }
-      : {}),
-    ...(typeof params.width === 'number' ? { width: params.width } : {}),
-    ...(typeof params.height === 'number' ? { height: params.height } : {}),
+    ...(params.width && params.height
+      ? { size: `${params.width}*${params.height}` }
+      : params.size
+        ? { size: params.size.replaceAll('x', '*') }
+        : { size: '1024*1024' }),
   };
 
   const response = await fetch(endpoint, {
@@ -240,7 +222,7 @@ async function createAsyncGenerationTask(
  * This is a synchronous API that returns the result directly
  * Supports both text-to-image (t2i) and image-to-image (i2i) workflows
  */
-async function createMultimodalGeneration(
+async function createHTTPSyncGeneration(
   payload: CreateImagePayload,
   apiKey: string,
   baseUrl: string,
@@ -283,6 +265,7 @@ async function createMultimodalGeneration(
       },
       model,
       parameters: {
+        n: 1,
         ...(typeof params.seed === 'number' ? { seed: params.seed } : {}),
       },
     }),
@@ -305,7 +288,7 @@ async function createMultimodalGeneration(
     );
   }
 
-  const data: QwenMultimodalGenerationResponse = await response.json();
+  const data: QwenImageTaskResponse = await response.json();
 
   const resultImageUrl = data.output.choices?.[0]?.message?.content?.find(
     (item) => !!item.image,
@@ -323,7 +306,7 @@ async function createMultimodalGeneration(
 /**
  * Query the status of an image generation task
  */
-async function queryTaskStatus(
+async function queryQwenTaskStatus(
   taskId: string,
   apiKey: string,
   baseUrl: string,
@@ -353,6 +336,52 @@ async function queryTaskStatus(
   return response.json();
 }
 
+async function pollTaskToImageResponse(
+  taskId: string,
+  apiKey: string,
+  baseUrl: string,
+  model: string,
+): Promise<CreateImageResponse> {
+  return asyncifyPolling<QwenImageTaskResponse, CreateImageResponse>({
+    checkStatus: (taskStatus: QwenImageTaskResponse): TaskResult<CreateImageResponse> => {
+      log('Task %s status: %s', taskId, taskStatus.output.task_status);
+
+      if (taskStatus.output.task_status === 'SUCCEEDED') {
+        const generatedImageUrl = extractImageUrlFromTaskResult(taskStatus);
+
+        if (!generatedImageUrl) {
+          return {
+            error: new Error('Task succeeded but no images generated'),
+            status: 'failed',
+          };
+        }
+
+        log('Image generated successfully: %s', generatedImageUrl);
+
+        return {
+          data: { imageUrl: generatedImageUrl },
+          status: 'success',
+        };
+      }
+
+      if (taskStatus.output.task_status === 'FAILED') {
+        const errorMessage = taskStatus.output.error_message || 'Task failed without error message';
+        return {
+          error: new Error(`Image generation failed for model ${model}: ${errorMessage}`),
+          status: 'failed',
+        };
+      }
+
+      return { status: 'pending' };
+    },
+    logger: {
+      debug: (message: any, ...args: any[]) => log(message, ...args),
+      error: (message: any, ...args: any[]) => log(message, ...args),
+    },
+    pollingQuery: () => queryQwenTaskStatus(taskId, apiKey, baseUrl),
+  });
+}
+
 /**
  * Create image using Qwen API
  * Supports three types:
@@ -377,104 +406,33 @@ export async function createQwenImage(
   try {
     const isText2Image = matchesModel(model, text2ImageModels);
     const isImage2Image = matchesModel(model, image2ImageModels);
-    const isAsyncGeneration = matchesModel(model, asyncGenerationModels);
+    const isAsyncGeneration = matchesModel(model, asyncOnlyModels);
 
     if (isText2Image || isImage2Image) {
       const endpoint = isImage2Image ? 'image2image' : 'text2image';
       log('Using %s API for model: %s', endpoint, model);
 
-      const taskId = await createQwenImageTask(payload, apiKey, endpoint, provider, dashscopeURL);
+      const taskId = await createLegacySynthesisTask(
+        payload,
+        apiKey,
+        endpoint,
+        provider,
+        dashscopeURL,
+      );
 
-      const result = await asyncifyPolling<QwenImageTaskResponse, CreateImageResponse>({
-        checkStatus: (taskStatus: QwenImageTaskResponse): TaskResult<CreateImageResponse> => {
-          log('Task %s status: %s', taskId, taskStatus.output.task_status);
-
-          if (taskStatus.output.task_status === 'SUCCEEDED') {
-            if (!taskStatus.output.results || taskStatus.output.results.length === 0) {
-              return {
-                error: new Error('Task succeeded but no images generated'),
-                status: 'failed',
-              };
-            }
-
-            const generatedImageUrl = taskStatus.output.results[0].url;
-            log('Image generated successfully: %s', generatedImageUrl);
-
-            return {
-              data: { imageUrl: generatedImageUrl },
-              status: 'success',
-            };
-          }
-
-          if (taskStatus.output.task_status === 'FAILED') {
-            const errorMessage =
-              taskStatus.output.error_message || 'Task failed without error message';
-            return {
-              error: new Error(`Image generation failed for model ${model}: ${errorMessage}`),
-              status: 'failed',
-            };
-          }
-
-          return { status: 'pending' };
-        },
-        logger: {
-          debug: (message: any, ...args: any[]) => log(message, ...args),
-          error: (message: any, ...args: any[]) => log(message, ...args),
-        },
-        pollingQuery: () => queryTaskStatus(taskId, apiKey, dashscopeURL),
-      });
-
-      return result;
+      return await pollTaskToImageResponse(taskId, apiKey, dashscopeURL, model);
     }
 
     if (isAsyncGeneration) {
       log('Using image-generation async API for model: %s', model);
 
-      const taskId = await createAsyncGenerationTask(payload, apiKey, dashscopeURL);
+      const taskId = await createHTTPAsyncGenerationTask(payload, apiKey, dashscopeURL);
 
-      return await asyncifyPolling<QwenImageTaskResponse, CreateImageResponse>({
-        checkStatus: (taskStatus: QwenImageTaskResponse): TaskResult<CreateImageResponse> => {
-          log('Task %s status: %s', taskId, taskStatus.output.task_status);
-
-          if (taskStatus.output.task_status === 'SUCCEEDED') {
-            const generatedImageUrl = extractImageUrlFromTaskResult(taskStatus);
-
-            if (!generatedImageUrl) {
-              return {
-                error: new Error('Task succeeded but no images generated'),
-                status: 'failed',
-              };
-            }
-
-            log('Image generated successfully: %s', generatedImageUrl);
-
-            return {
-              data: { imageUrl: generatedImageUrl },
-              status: 'success',
-            };
-          }
-
-          if (taskStatus.output.task_status === 'FAILED') {
-            const errorMessage =
-              taskStatus.output.error_message || 'Task failed without error message';
-            return {
-              error: new Error(`Image generation failed for model ${model}: ${errorMessage}`),
-              status: 'failed',
-            };
-          }
-
-          return { status: 'pending' };
-        },
-        logger: {
-          debug: (message: any, ...args: any[]) => log(message, ...args),
-          error: (message: any, ...args: any[]) => log(message, ...args),
-        },
-        pollingQuery: () => queryTaskStatus(taskId, apiKey, dashscopeURL),
-      });
+      return await pollTaskToImageResponse(taskId, apiKey, dashscopeURL, model);
     }
 
     log('Using multimodal-generation API for model: %s', model);
-    return await createMultimodalGeneration(payload, apiKey, dashscopeURL);
+    return await createHTTPSyncGeneration(payload, apiKey, dashscopeURL);
   } catch (error) {
     log('Error in createQwenImage: %O', error);
 

--- a/packages/model-runtime/src/providers/qwen/createImage.ts
+++ b/packages/model-runtime/src/providers/qwen/createImage.ts
@@ -18,6 +18,8 @@ const text2ImageModels = [
 
 const image2ImageModels = [/^wan2\.(2|5)-i2i-/];
 
+const asyncGenerationModels = [/^wan2\.7-image/, /^kling\/.+-image-generation$/];
+
 const imageRequiredModels = [/^qwen-image-edit/, /^wan2\.(2|5)-i2i-/, /^wan2\.6-image/];
 
 // Helper function to check if model matches any pattern in the array
@@ -29,7 +31,16 @@ function matchesModel(model: string, patterns: Array<string | RegExp>): boolean 
 
 interface QwenImageTaskResponse {
   output: {
+    choices?: Array<{
+      message?: {
+        content?: Array<{
+          image?: string;
+          type?: string;
+        }>;
+      };
+    }>;
     error_message?: string;
+    finished?: boolean;
     results?: Array<{
       url: string;
     }>;
@@ -39,18 +50,28 @@ interface QwenImageTaskResponse {
   request_id: string;
 }
 
-// Interface for multimodal-generation response
 interface QwenMultimodalGenerationResponse {
   output: {
-    choices: Array<{
-      message: {
-        content: Array<{
-          image: string;
+    choices?: Array<{
+      message?: {
+        content?: Array<{
+          image?: string;
         }>;
       };
     }>;
   };
   request_id: string;
+}
+
+function extractImageUrlFromTaskResult(taskStatus: QwenImageTaskResponse): string | undefined {
+  const generatedImageUrl = taskStatus.output.results?.[0]?.url;
+  if (generatedImageUrl) return generatedImageUrl;
+
+  const generatedChoiceImage = taskStatus.output.choices?.[0]?.message?.content?.find(
+    (item) => !!item.image,
+  )?.image;
+
+  return generatedChoiceImage;
 }
 
 /**
@@ -133,6 +154,88 @@ async function createQwenImageTask(
 }
 
 /**
+ * Create an async image-generation task with Qwen API
+ * Used by newer async models like wan2.7-image and kling image-generation family
+ */
+async function createAsyncGenerationTask(
+  payload: CreateImagePayload,
+  apiKey: string,
+  baseUrl: string,
+): Promise<string> {
+  const { model, params } = payload;
+  const endpoint = `${baseUrl}/api/v1/services/aigc/image-generation/generation`;
+  log('Creating async generation task with model: %s, endpoint: %s', model, endpoint);
+
+  const content: Array<{ image: string } | { text: string }> = [{ text: params.prompt }];
+
+  if (params.imageUrl) {
+    content.push({ image: params.imageUrl });
+  }
+
+  if (params.imageUrls && params.imageUrls.length > 0) {
+    for (const imageUrl of params.imageUrls) {
+      content.push({ image: imageUrl });
+    }
+  }
+
+  const optionalParams = params as Record<string, unknown>;
+  const parameters: Record<string, unknown> = {
+    ...(typeof params.seed === 'number' ? { seed: params.seed } : {}),
+    ...(typeof optionalParams.n === 'number' ? { n: optionalParams.n } : {}),
+    ...(typeof optionalParams.resultType === 'string'
+      ? { result_type: optionalParams.resultType }
+      : {}),
+    ...(typeof optionalParams.aspectRatio === 'string'
+      ? { aspect_ratio: optionalParams.aspectRatio }
+      : {}),
+    ...(typeof optionalParams.resolution === 'string'
+      ? { resolution: optionalParams.resolution }
+      : {}),
+    ...(typeof params.width === 'number' ? { width: params.width } : {}),
+    ...(typeof params.height === 'number' ? { height: params.height } : {}),
+  };
+
+  const response = await fetch(endpoint, {
+    body: JSON.stringify({
+      input: {
+        messages: [
+          {
+            content,
+            role: 'user',
+          },
+        ],
+      },
+      model,
+      parameters,
+    }),
+    headers: {
+      'Authorization': `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+      'X-DashScope-Async': 'enable',
+    },
+    method: 'POST',
+  });
+
+  if (!response.ok) {
+    let errorData;
+    try {
+      errorData = await response.json();
+    } catch {
+      // Failed to parse JSON error response
+    }
+
+    throw new Error(
+      `Failed to create async generation task for model ${model} (${response.status}): ${errorData?.message || response.statusText}`,
+    );
+  }
+
+  const data: QwenImageTaskResponse = await response.json();
+  log('Async generation task created with ID: %s', data.output.task_id);
+
+  return data.output.task_id;
+}
+
+/**
  * Create image with Qwen multimodal-generation API
  * This is a synchronous API that returns the result directly
  * Supports both text-to-image (t2i) and image-to-image (i2i) workflows
@@ -204,21 +307,14 @@ async function createMultimodalGeneration(
 
   const data: QwenMultimodalGenerationResponse = await response.json();
 
-  if (!data.output.choices || data.output.choices.length === 0) {
-    throw new Error(`No image choices returned from API for model ${model}`);
-  }
+  const resultImageUrl = data.output.choices?.[0]?.message?.content?.find(
+    (item) => !!item.image,
+  )?.image;
 
-  const choice = data.output.choices[0];
-  if (!choice.message.content || choice.message.content.length === 0) {
-    throw new Error(`No image content returned from API for model ${model}`);
-  }
-
-  const imageContent = choice.message.content.find((content) => 'image' in content);
-  if (!imageContent) {
+  if (!resultImageUrl) {
     throw new Error(`No image found in response content for model ${model}`);
   }
 
-  const resultImageUrl = imageContent.image;
   log('Image edit generated successfully: %s', resultImageUrl);
 
   return { imageUrl: resultImageUrl };
@@ -262,7 +358,8 @@ async function queryTaskStatus(
  * Supports three types:
  * - text2image (async with polling for legacy models)
  * - image2image (async with polling for legacy models)
- * - multimodal-generation (sync for new models, default fallback)
+ * - image-generation (async with polling for new async models)
+ * - multimodal-generation (sync for remaining models, default fallback)
  */
 export async function createQwenImage(
   payload: CreateImagePayload,
@@ -280,6 +377,7 @@ export async function createQwenImage(
   try {
     const isText2Image = matchesModel(model, text2ImageModels);
     const isImage2Image = matchesModel(model, image2ImageModels);
+    const isAsyncGeneration = matchesModel(model, asyncGenerationModels);
 
     if (isText2Image || isImage2Image) {
       const endpoint = isImage2Image ? 'image2image' : 'text2image';
@@ -327,6 +425,52 @@ export async function createQwenImage(
       });
 
       return result;
+    }
+
+    if (isAsyncGeneration) {
+      log('Using image-generation async API for model: %s', model);
+
+      const taskId = await createAsyncGenerationTask(payload, apiKey, dashscopeURL);
+
+      return await asyncifyPolling<QwenImageTaskResponse, CreateImageResponse>({
+        checkStatus: (taskStatus: QwenImageTaskResponse): TaskResult<CreateImageResponse> => {
+          log('Task %s status: %s', taskId, taskStatus.output.task_status);
+
+          if (taskStatus.output.task_status === 'SUCCEEDED') {
+            const generatedImageUrl = extractImageUrlFromTaskResult(taskStatus);
+
+            if (!generatedImageUrl) {
+              return {
+                error: new Error('Task succeeded but no images generated'),
+                status: 'failed',
+              };
+            }
+
+            log('Image generated successfully: %s', generatedImageUrl);
+
+            return {
+              data: { imageUrl: generatedImageUrl },
+              status: 'success',
+            };
+          }
+
+          if (taskStatus.output.task_status === 'FAILED') {
+            const errorMessage =
+              taskStatus.output.error_message || 'Task failed without error message';
+            return {
+              error: new Error(`Image generation failed for model ${model}: ${errorMessage}`),
+              status: 'failed',
+            };
+          }
+
+          return { status: 'pending' };
+        },
+        logger: {
+          debug: (message: any, ...args: any[]) => log(message, ...args),
+          error: (message: any, ...args: any[]) => log(message, ...args),
+        },
+        pollingQuery: () => queryTaskStatus(taskId, apiKey, dashscopeURL),
+      });
     }
 
     log('Using multimodal-generation API for model: %s', model);


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [X] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Sourcery 总结

为新的 Qwen 图像生成模型和路由增加支持，包括对 Kling 和 万象 2.7 图像模型的异步处理。

新功能：
- 将 Wanxiang2.7 Image 和 Wanxiang2.7 Image Pro 作为可选的 Qwen 图像模型暴露出来，并附带相应的参数和定价元数据。
- 将 Kling V3 Image Generation 和 Kling V3 Omni Image Generation 作为可选的 Qwen 图像模型暴露出来，支持可配置的长宽比、分辨率以及参考图像。

增强：
- 针对需要异步处理的模型，引入专用的异步图像生成流程，使用图像生成 API，并为旧路由和新路由共享一个通用的轮询辅助工具。
- 统一 Qwen 图像任务的响应解析逻辑，以同时支持基于 URL 的结果及多模态 choices 负载，并确保同步的多模态生成请求始终只请求单张图像。

测试：
- 添加测试以覆盖 Kling 模型新的异步图像生成路由，以及 Wanxiang 2.7 模型的多模态生成同步流程，包括对请求负载的校验。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for new Qwen image-generation models and routes, including async handling for Kling and Wanxiang 2.7 image models.

New Features:
- Expose Wanxiang2.7 Image and Wanxiang2.7 Image Pro as selectable Qwen image models with appropriate parameters and pricing metadata.
- Expose Kling V3 Image Generation and Kling V3 Omni Image Generation as selectable Qwen image models with configurable aspect ratio, resolution, and reference images.

Enhancements:
- Introduce a dedicated async image-generation flow using the image-generation API for models that require asynchronous handling, sharing a common polling helper for legacy and new routes.
- Unify response parsing for Qwen image tasks to support both URL-based results and multimodal choices payloads, and ensure synchronous multimodal-generation requests always request a single image.

Tests:
- Add tests covering the new async image-generation route for Kling models and the multimodal-generation sync flow for Wanxiang 2.7 models, including request payload validation.

</details>