### PR TITLE
🐛 fix(image,video): preserve prompt and image when switching model

### DIFF
--- a/src/store/image/slices/generationConfig/action.test.ts
+++ b/src/store/image/slices/generationConfig/action.test.ts
@@ -24,6 +24,7 @@ vi.mock('@/store/user/slices/settings/selectors', () => ({
 // Test fixtures
 const customModelSchema: ModelParamsSchema = {
   prompt: { default: '' },
+  imageUrls: { default: [] },
   width: { default: 1024, min: 256, max: 2048, step: 64 },
   height: { default: 1024, min: 256, max: 2048, step: 64 },
   steps: { default: 20, min: 1, max: 50 },
@@ -195,22 +196,27 @@ describe('GenerationConfigAction', () => {
       expect(result.current.parametersSchema).toEqual(customModelSchema);
     });
 
-    it('should completely replace parameters when switching models', () => {
+    it('should preserve prompt and image inputs when switching models', () => {
       const { result } = renderHook(() => useImageStore());
 
       // Set some custom parameters
       act(() => {
         result.current.setParamOnInput('prompt', 'custom prompt');
+        result.current.setParamOnInput('imageUrls', ['custom-image-1.png']);
         result.current.setParamOnInput('steps', 50);
       });
 
       // Switch model
       act(() => {
-        result.current.setModelAndProviderOnSelect('flux/schnell', 'fal');
+        result.current.setModelAndProviderOnSelect('custom-model', 'custom-provider');
       });
 
-      expect(result.current.parameters).toEqual(fluxSchnellDefaultValues);
-      expect(result.current.parameters?.prompt).toBe('');
+      expect(result.current.parameters).toEqual({
+        ...customModelDefaultValues,
+        prompt: 'custom prompt',
+        imageUrls: ['custom-image-1.png'],
+      });
+      expect(result.current.parameters?.steps).toBe(customModelDefaultValues.steps);
     });
   });
 

--- a/src/store/image/slices/generationConfig/action.test.ts
+++ b/src/store/image/slices/generationConfig/action.test.ts
@@ -45,6 +45,17 @@ const testImageModels: AIImageModelCard[] = [
     parameters: customModelSchema,
     releasedAt: '2024-01-01',
   },
+  {
+    id: 'single-image-model',
+    displayName: 'Single Image Model',
+    type: 'image',
+    parameters: {
+      prompt: { default: '' },
+      imageUrl: { default: '' },
+      steps: { default: 20, min: 1, max: 50 },
+    } as ModelParamsSchema,
+    releasedAt: '2024-01-01',
+  },
 ];
 
 const mockProviders = [
@@ -57,6 +68,11 @@ const mockProviders = [
     id: 'custom-provider',
     name: 'Custom Provider',
     children: [testImageModels[1]],
+  },
+  {
+    id: 'single-image-provider',
+    name: 'Single Image Provider',
+    children: [testImageModels[2]],
   },
 ];
 
@@ -217,6 +233,58 @@ describe('GenerationConfigAction', () => {
         imageUrls: ['custom-image-1.png'],
       });
       expect(result.current.parameters?.steps).toBe(customModelDefaultValues.steps);
+    });
+
+    it('should convert imageUrls[0] to imageUrl when switching to single-image model', () => {
+      const { result } = renderHook(() => useImageStore());
+
+      // Set up multi-image state with imageUrls
+      act(() => {
+        result.current.setParamOnInput('prompt', 'test prompt');
+        result.current.setParamOnInput('imageUrls', ['image1.png', 'image2.png', 'image3.png']);
+      });
+
+      // Switch to single-image model - should convert imageUrls[0] to imageUrl
+      act(() => {
+        result.current.setModelAndProviderOnSelect('single-image-model', 'single-image-provider');
+      });
+
+      expect(result.current.parameters?.imageUrl).toBe('image1.png');
+      expect(result.current.parameters?.prompt).toBe('test prompt');
+      expect(result.current.parameters?.imageUrls).toBeUndefined();
+    });
+
+    it('should convert imageUrl to imageUrls array when switching to multi-image model', () => {
+      const { result } = renderHook(() => useImageStore());
+      const singleImageSchema: ModelParamsSchema = {
+        prompt: { default: '' },
+        imageUrl: { default: '' },
+        steps: { default: 20, min: 1, max: 50 },
+      };
+
+      // Initialize with single-image model state
+      useImageStore.setState({
+        model: 'single-image-model',
+        provider: 'single-image-provider',
+        parameters: {
+          prompt: 'test prompt',
+          imageUrl: 'reference-image.png',
+          steps: 20,
+        },
+        parametersSchema: singleImageSchema,
+      });
+
+      // Get fresh hook after state update
+      const { result: storeResult } = renderHook(() => useImageStore());
+
+      // Switch to multi-image model - should convert imageUrl to imageUrls array
+      act(() => {
+        storeResult.current.setModelAndProviderOnSelect('custom-model', 'custom-provider');
+      });
+
+      expect(storeResult.current.parameters?.imageUrls).toEqual(['reference-image.png']);
+      expect(storeResult.current.parameters?.prompt).toBe('test prompt');
+      expect(storeResult.current.parameters?.imageUrl).toBeUndefined();
     });
   });
 

--- a/src/store/image/slices/generationConfig/action.ts
+++ b/src/store/image/slices/generationConfig/action.ts
@@ -70,11 +70,40 @@ function preserveImageInputParams(
   nextDefaultValues: RuntimeImageGenParams,
   nextSchema: ModelParamsSchema,
 ) {
-  return preserveSupportedParams(previousParameters, nextDefaultValues, nextSchema, [
+  const result = preserveSupportedParams(previousParameters, nextDefaultValues, nextSchema, [
     'prompt',
     'imageUrl',
     'imageUrls',
   ]);
+
+  // Smart conversion: multi-image ↔ single-image model switching
+  const { imageUrl, imageUrls } = previousParameters;
+  const supportsImageUrl = 'imageUrl' in nextSchema;
+  const supportsImageUrls = 'imageUrls' in nextSchema;
+
+  // Case 1: Multi-image → Single-image (imageUrls[0] → imageUrl)
+  if (
+    Array.isArray(imageUrls) &&
+    imageUrls.length > 0 &&
+    !supportsImageUrls &&
+    supportsImageUrl &&
+    !result.imageUrl
+  ) {
+    (result as RuntimeImageGenParams).imageUrl = imageUrls[0];
+  }
+
+  // Case 2: Single-image → Multi-image (imageUrl → [imageUrl])
+  if (
+    typeof imageUrl === 'string' &&
+    imageUrl.length > 0 &&
+    !supportsImageUrl &&
+    supportsImageUrls &&
+    !result.imageUrls
+  ) {
+    (result as RuntimeImageGenParams).imageUrls = [imageUrl];
+  }
+
+  return result;
 }
 
 type Setter = StoreSetter<ImageStore>;

--- a/src/store/image/slices/generationConfig/action.ts
+++ b/src/store/image/slices/generationConfig/action.ts
@@ -14,6 +14,7 @@ import { useUserStore } from '@/store/user';
 import { authSelectors } from '@/store/user/selectors';
 import { settingsSelectors } from '@/store/user/slices/settings/selectors';
 
+import { preserveSupportedParams } from '../../../utils/preserveSupportedParams';
 import { type ImageStore } from '../../store';
 import { calculateInitialAspectRatio } from '../../utils/aspectRatio';
 import { adaptSizeToRatio, parseRatio } from '../../utils/size';
@@ -62,6 +63,18 @@ function prepareModelConfigState(model: string, provider: string) {
     parametersSchema,
     initialActiveRatio,
   };
+}
+
+function preserveImageInputParams(
+  previousParameters: RuntimeImageGenParams,
+  nextDefaultValues: RuntimeImageGenParams,
+  nextSchema: ModelParamsSchema,
+) {
+  return preserveSupportedParams(previousParameters, nextDefaultValues, nextSchema, [
+    'prompt',
+    'imageUrl',
+    'imageUrls',
+  ]);
 }
 
 type Setter = StoreSetter<ImageStore>;
@@ -244,16 +257,23 @@ export class GenerationConfigActionImpl {
   };
 
   setModelAndProviderOnSelect = (model: string, provider: string): void => {
+    const previousParameters = this.#get().parameters;
     const { defaultValues, parametersSchema, initialActiveRatio } = prepareModelConfigState(
       model,
       provider,
+    );
+
+    const parameters = preserveImageInputParams(
+      previousParameters,
+      defaultValues,
+      parametersSchema,
     );
 
     this.#set(
       {
         model,
         provider,
-        parameters: defaultValues,
+        parameters,
         parametersSchema,
         isAspectRatioLocked: false,
         activeAspectRatio: initialActiveRatio,

--- a/src/store/utils/preserveSupportedParams.ts
+++ b/src/store/utils/preserveSupportedParams.ts
@@ -1,0 +1,24 @@
+export function preserveSupportedParams<
+  TParams extends Record<string, unknown>,
+  TSchema extends Record<string, unknown>,
+  TKey extends keyof TParams & string,
+>(
+  previousParameters: TParams,
+  nextDefaultValues: TParams,
+  nextSchema: TSchema,
+  keys: readonly TKey[],
+): TParams {
+  const supportedPreservedEntries = keys.flatMap((key) => {
+    if (!(key in nextSchema)) return [];
+
+    const value = previousParameters[key];
+    if (typeof value === 'undefined') return [];
+
+    return [[key, value] as const];
+  });
+
+  return {
+    ...nextDefaultValues,
+    ...Object.fromEntries(supportedPreservedEntries),
+  };
+}

--- a/src/store/video/slices/generationConfig/action.test.ts
+++ b/src/store/video/slices/generationConfig/action.test.ts
@@ -1,0 +1,109 @@
+import { act, renderHook } from '@testing-library/react';
+import {
+  type AIVideoModelCard,
+  extractVideoDefaultValues,
+  type RuntimeVideoGenParams,
+  type VideoModelParamsSchema,
+} from 'model-bank';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useVideoStore } from '@/store/video';
+
+const modelASchema: VideoModelParamsSchema = {
+  prompt: { default: '' },
+  imageUrl: { default: '' },
+  endImageUrl: { default: '' },
+  duration: { default: 5, min: 1, max: 10 },
+};
+
+const modelBSchema: VideoModelParamsSchema = {
+  prompt: { default: '' },
+  imageUrl: { default: '' },
+  endImageUrl: { default: '' },
+  duration: { default: 3, min: 1, max: 10 },
+};
+
+const testVideoModels: AIVideoModelCard[] = [
+  {
+    id: 'video-model-a',
+    displayName: 'Video Model A',
+    type: 'video',
+    parameters: modelASchema,
+    releasedAt: '2025-01-01',
+  },
+  {
+    id: 'video-model-b',
+    displayName: 'Video Model B',
+    type: 'video',
+    parameters: modelBSchema,
+    releasedAt: '2025-01-02',
+  },
+];
+
+const mockProviders = [
+  {
+    id: 'provider-a',
+    name: 'Provider A',
+    children: [testVideoModels[0]],
+  },
+  {
+    id: 'provider-b',
+    name: 'Provider B',
+    children: [testVideoModels[1]],
+  },
+];
+
+vi.mock('@/store/aiInfra', () => ({
+  aiProviderSelectors: {
+    enabledVideoModelList: vi.fn(() => mockProviders),
+  },
+  getAiInfraStoreState: vi.fn(() => ({})),
+}));
+
+const modelBDefaultValues = extractVideoDefaultValues(modelBSchema);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+
+  useVideoStore.setState({
+    isInit: true,
+    model: 'video-model-a',
+    provider: 'provider-a',
+    parametersSchema: modelASchema,
+    parameters: {
+      prompt: 'initial prompt',
+      imageUrl: 'start-frame.png',
+      endImageUrl: 'end-frame.png',
+      duration: 6,
+    } as RuntimeVideoGenParams,
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('video generationConfig actions', () => {
+  it('should preserve prompt and frame images when switching model', () => {
+    const { result } = renderHook(() => useVideoStore());
+
+    act(() => {
+      result.current.setParamOnInput('prompt', 'cinematic sunset');
+      result.current.setParamOnInput('imageUrl', 'start-custom.png');
+      result.current.setParamOnInput('endImageUrl', 'end-custom.png');
+      result.current.setParamOnInput('duration', 8);
+    });
+
+    act(() => {
+      result.current.setModelAndProviderOnSelect('video-model-b', 'provider-b');
+    });
+
+    expect(result.current.parameters).toEqual({
+      ...modelBDefaultValues,
+      prompt: 'cinematic sunset',
+      imageUrl: 'start-custom.png',
+      endImageUrl: 'end-custom.png',
+    });
+    expect(result.current.parameters?.duration).toBe(modelBDefaultValues.duration);
+  });
+});

--- a/src/store/video/slices/generationConfig/action.ts
+++ b/src/store/video/slices/generationConfig/action.ts
@@ -1,6 +1,7 @@
 import {
   type AIVideoModelCard,
   extractVideoDefaultValues,
+  type RuntimeVideoGenParams,
   type RuntimeVideoGenParamsKeys,
   type RuntimeVideoGenParamsValue,
   type VideoModelParamsSchema,
@@ -12,6 +13,7 @@ import { type StoreSetter } from '@/store/types';
 import { useUserStore } from '@/store/user';
 import { authSelectors } from '@/store/user/selectors';
 
+import { preserveSupportedParams } from '../../../utils/preserveSupportedParams';
 import type { VideoStore } from '../../store';
 
 export function getVideoModelAndDefaults(model: string, provider: string) {
@@ -39,17 +41,30 @@ export function getVideoModelAndDefaults(model: string, provider: string) {
   return { activeModel, defaultValues, parametersSchema };
 }
 
+function preserveVideoInputParams(
+  previousParameters: RuntimeVideoGenParams,
+  nextDefaultValues: RuntimeVideoGenParams,
+  nextSchema: VideoModelParamsSchema,
+) {
+  return preserveSupportedParams(previousParameters, nextDefaultValues, nextSchema, [
+    'prompt',
+    'imageUrl',
+    'endImageUrl',
+  ]);
+}
+
 type Setter = StoreSetter<VideoStore>;
 
 export const createGenerationConfigSlice = (set: Setter, get: () => VideoStore, _api?: unknown) =>
   new GenerationConfigActionImpl(set, get, _api);
 
 export class GenerationConfigActionImpl {
+  readonly #get: () => VideoStore;
   readonly #set: Setter;
 
-  constructor(set: Setter, _get: () => VideoStore, _api?: unknown) {
-    void _get;
+  constructor(set: Setter, get: () => VideoStore, _api?: unknown) {
     void _api;
+    this.#get = get;
     this.#set = set;
   }
 
@@ -85,12 +100,18 @@ export class GenerationConfigActionImpl {
   };
 
   setModelAndProviderOnSelect = (model: string, provider: string): void => {
+    const previousParameters = this.#get().parameters;
     const { defaultValues, parametersSchema } = getVideoModelAndDefaults(model, provider);
+    const parameters = preserveVideoInputParams(
+      previousParameters,
+      defaultValues,
+      parametersSchema,
+    );
 
     this.#set(
       {
         model,
-        parameters: defaultValues,
+        parameters,
         parametersSchema,
         provider,
       },


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

在切换图像和视频生成模型时保留用户已输入的内容，避免正在配置中的设置丢失。

Bug 修复：
- 在更改图像生成模型和提供商时，保持提示词和与图像相关的输入不变。
- 在更改视频生成模型和提供商时，保持提示词和帧图像输入不变。

测试：
- 扩展图像生成配置测试，用于验证在模型切换过程中提示词和图像输入能够被保留。
- 添加视频生成配置测试，用于验证在模型切换时提示词和帧图像参数能够持续存在。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Preserve user-entered inputs when switching image and video generation models to avoid losing in-progress configurations.

Bug Fixes:
- Keep prompt and image-related inputs when changing image generation model and provider.
- Keep prompt and frame image inputs when changing video generation model and provider.

Tests:
- Extend image generation config tests to validate preservation of prompt and image inputs across model switches.
- Add video generation config tests to verify prompt and frame image parameters persist when switching models.

</details>