### PR TITLE
🐛 fix: expose CRAWLER_TIMEOUT env for crawler

### DIFF
--- a/packages/web-crawler/src/utils/withTimeout.ts
+++ b/packages/web-crawler/src/utils/withTimeout.ts
@@ -1,6 +1,8 @@
 import { TimeoutError } from './errorType';
 
-export const DEFAULT_TIMEOUT = 10_000;
+export const DEFAULT_TIMEOUT = process.env.CRAWLER_TIMEOUT
+  ? Number(process.env.CRAWLER_TIMEOUT)
+  : 10_000;
 
 /**
  * Wraps a factory function with a timeout and abort support.


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [X] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

错误修复：
- 允许通过 `CRAWLER_TIMEOUT` 环境变量覆盖爬虫的默认超时时间。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Allow overriding the crawler's default timeout using the CRAWLER_TIMEOUT environment variable.

</details>