### PR TITLE
🔨 chore: add APP-Code for AiHubMix

### DIFF
--- a/packages/model-runtime/src/core/anthropicCompatibleFactory/index.ts
+++ b/packages/model-runtime/src/core/anthropicCompatibleFactory/index.ts
@@ -487,6 +487,7 @@ export const createAnthropicCompatibleRuntime = <T extends Record<string, any> =
       const {
         apiKey: finalApiKey,
         baseURL: finalBaseURL = DEFAULT_BASE_URL,
+        defaultHeaders,
         ...rest
       } = resolvedOptions;
       this._options = resolvedOptions as ConstructorOptions<T>;
@@ -497,6 +498,12 @@ export const createAnthropicCompatibleRuntime = <T extends Record<string, any> =
       const initOptions = {
         apiKey: finalApiKey,
         baseURL: finalBaseURL,
+        defaultHeaders: {
+          ...defaultHeaders,
+          ...(finalBaseURL === 'https://aihubmix.com' && {
+            'APP-Code': 'LobeHub',
+          }),
+        },
         ...constructorOptions,
         ...rest,
         timeout: rest.timeout ?? constructorOptions?.timeout ?? resolveDefaultAnthropicTimeout(),

--- a/packages/model-runtime/src/core/openaiCompatibleFactory/index.ts
+++ b/packages/model-runtime/src/core/openaiCompatibleFactory/index.ts
@@ -335,13 +335,24 @@ export const createOpenAICompatibleRuntime = <T extends Record<string, any> = an
         apiKey: inputOptions.apiKey?.trim() || DEFAULT_API_KEY,
         baseURL: inputOptions.baseURL?.trim() || DEFAULT_BASE_URL,
       };
-      const { apiKey, baseURL = DEFAULT_BASE_URL, ...res } = _options;
+      const { apiKey, baseURL = DEFAULT_BASE_URL, defaultHeaders, ...res } = _options;
       this._options = _options as ConstructorOptions<T>;
       this.modelIdMappingOptions = { modelIdMapping };
 
       if (!apiKey) throw AgentRuntimeError.createError(ErrorType?.invalidAPIKey);
 
-      const initOptions = { apiKey, baseURL, ...constructorOptions, ...res };
+      const initOptions = {
+        apiKey,
+        baseURL,
+        ...constructorOptions,
+        ...res,
+        defaultHeaders: {
+          ...defaultHeaders,
+          ...(baseURL === 'https://aihubmix.com/v1' && {
+            'APP-Code': 'LobeHub',
+          }),
+        },
+      };
 
       // if the custom client is provided, use it as client
       if (customClient?.createClient) {

--- a/packages/model-runtime/src/providers/google/index.ts
+++ b/packages/model-runtime/src/providers/google/index.ts
@@ -128,7 +128,15 @@ export class LobeGoogleAI implements LobeRuntimeAI {
     if (!apiKey) throw AgentRuntimeError.createError(AgentRuntimeErrorType.InvalidProviderAPIKey);
 
     const httpOptions = baseURL
-      ? ({ baseUrl: baseURL, headers: defaultHeaders } as HttpOptions)
+      ? ({
+          baseUrl: baseURL,
+          headers: {
+            ...defaultHeaders,
+            ...(baseURL === 'https://aihubmix.com/gemini' && {
+              'APP-Code': 'LobeHub',
+            }),
+          },
+        } as HttpOptions)
       : undefined;
 
     this.apiKey = apiKey;


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

为 OpenAI、Google 和 Anthropic 兼容的运行时，在指向 AiHubMix 端点时添加自动注入 APP-Code 请求头的功能。

增强内容：
- 在初始化 OpenAI 兼容的运行时客户端时传播可选的默认请求头，并在使用 AiHubMix 基础 URL 时注入 APP-Code。
- 扩展 Google 提供方的 HTTP 配置选项，以合并默认请求头，并在目标是 AiHubMix Gemini 端点时设置 APP-Code。
- 更新 Anthropic 兼容运行时的初始化逻辑，以支持默认请求头，并在使用 AiHubMix 基础 URL 时添加 APP-Code。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add automatic APP-Code header injection for AiHubMix endpoints across OpenAI-, Google-, and Anthropic-compatible runtimes.

Enhancements:
- Propagate optional default headers when initializing OpenAI-compatible runtime clients and inject APP-Code for AiHubMix base URL.
- Extend Google provider HTTP options to merge default headers and set APP-Code when targeting AiHubMix Gemini endpoint.
- Update Anthropic-compatible runtime initialization to honor default headers and add APP-Code when using AiHubMix base URL.

</details>