### PR TITLE
fix: fix memory persona writer error

### DIFF
--- a/src/server/globalConfig/parseMemoryExtractionConfig.ts
+++ b/src/server/globalConfig/parseMemoryExtractionConfig.ts
@@ -44,6 +44,8 @@ export interface MemoryExtractionPrivateConfig {
   agentLayerExtractorPreferredModels?: string[];
   agentLayerExtractorPreferredProviders?: string[];
   agentPersonaWriter: MemoryAgentConfig;
+  agentPersonaWriterPreferredModels?: string[];
+  agentPersonaWriterPreferredProviders?: string[];
   concurrency?: number;
   embedding: MemoryAgentConfig;
   embeddingPreferredModels?: string[];
@@ -264,6 +266,12 @@ export const parseMemoryExtractionConfig = (): MemoryExtractionPrivateConfig => 
   const agentLayerExtractorPreferredModels = parsePreferredList(
     process.env.MEMORY_USER_MEMORY_LAYER_EXTRACTOR_PREFERRED_MODELS,
   );
+  const agentPersonaWriterPreferredProviders = parsePreferredList(
+    process.env.MEMORY_USER_MEMORY_PERSONA_WRITER_PREFERRED_PROVIDERS,
+  );
+  const agentPersonaWriterPreferredModels = parsePreferredList(
+    process.env.MEMORY_USER_MEMORY_PERSONA_WRITER_PREFERRED_MODELS,
+  );
 
   return {
     agentGateKeeper,
@@ -273,6 +281,8 @@ export const parseMemoryExtractionConfig = (): MemoryExtractionPrivateConfig => 
     agentLayerExtractorPreferredModels,
     agentLayerExtractorPreferredProviders,
     agentPersonaWriter,
+    agentPersonaWriterPreferredModels,
+    agentPersonaWriterPreferredProviders,
     concurrency,
     embedding,
     embeddingPreferredModels,

--- a/src/server/services/memory/userMemory/persona/__tests__/service.test.ts
+++ b/src/server/services/memory/userMemory/persona/__tests__/service.test.ts
@@ -37,6 +37,8 @@ vi.mock('@/server/globalConfig/parseMemoryExtractionConfig', () => ({
       model: 'gpt-mock',
       provider: 'openai',
     },
+    agentLayerExtractorPreferredModels: ['gpt-mock'],
+    agentLayerExtractorPreferredProviders: ['openai'],
     agentPersonaWriter: {
       apiKey: 'test-key',
       baseURL: 'https://example.com',
@@ -44,6 +46,8 @@ vi.mock('@/server/globalConfig/parseMemoryExtractionConfig', () => ({
       model: 'gpt-mock',
       provider: 'openai',
     },
+    agentPersonaWriterPreferredModels: ['gpt-mock'],
+    agentPersonaWriterPreferredProviders: ['openai'],
   }),
 }));
 
@@ -131,6 +135,22 @@ describe('UserPersonaService', () => {
     expect(toolCall).toHaveBeenLastCalledWith(
       expect.objectContaining({
         existingPersona: '# Persona',
+      }),
+    );
+  });
+
+  it('passes persona writer preferred lists to runtime resolution', async () => {
+    const service = new UserPersonaService(db);
+
+    await service.composeWriting({ userId, username: 'User' });
+
+    expect(aiInfraMocks.tryMatchingProviderFrom).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.objectContaining({
+        fallbackProvider: 'openai',
+        modelId: 'gpt-mock',
+        preferredModels: ['gpt-mock'],
+        preferredProviders: ['openai'],
       }),
     );
   });

--- a/src/server/services/memory/userMemory/persona/service.ts
+++ b/src/server/services/memory/userMemory/persona/service.ts
@@ -51,13 +51,21 @@ export class UserPersonaService {
   private readonly preferredLanguage?: string;
   private readonly db: LobeChatDatabase;
   private readonly agentConfig: MemoryAgentConfig;
+  private readonly preferredModels?: string[];
+  private readonly preferredProviders?: string[];
 
   constructor(db: LobeChatDatabase) {
-    const { agentPersonaWriter } = parseMemoryExtractionConfig();
+    const {
+      agentPersonaWriter,
+      agentPersonaWriterPreferredModels,
+      agentPersonaWriterPreferredProviders,
+    } = parseMemoryExtractionConfig();
 
     this.db = db;
     this.preferredLanguage = agentPersonaWriter.language;
     this.agentConfig = agentPersonaWriter;
+    this.preferredModels = agentPersonaWriterPreferredModels;
+    this.preferredProviders = agentPersonaWriterPreferredProviders;
   }
 
   async composeWriting(payload: UserPersonaAgentPayload): Promise<UserPersonaAgentResult> {
@@ -69,11 +77,22 @@ export class UserPersonaService {
       fallbackProvider: this.agentConfig.provider,
       label: 'persona writer',
       modelId: this.agentConfig.model,
+      preferredModels: this.preferredModels,
+      preferredProviders: this.preferredProviders,
     });
 
-    const keyVaults: ProviderKeyVaultMap = Object.entries(runtimeState.runtimeConfig || {}).reduce(
+    const normalizedRuntimeConfig = Object.fromEntries(
+      Object.entries(runtimeState.runtimeConfig || {}).map(([provider, config]) => [
+        provider.toLowerCase(),
+        config,
+      ]),
+    );
+
+    const keyVaults: ProviderKeyVaultMap = Object.entries(normalizedRuntimeConfig).reduce(
       (acc, [provider, config]) => {
-        acc[provider.toLowerCase()] = config?.keyVaults;
+        if (provider !== providerId) return acc;
+
+        acc[provider] = config?.keyVaults;
         return acc;
       },
       {} as ProviderKeyVaultMap,


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

为 persona writer 提供首选模型/提供商配置支持，并确保在运行时解析过程中使用正确的提供商密钥保管库（key vault）。

New Features:
- 允许通过环境变量和全局内存抽取配置，为 persona writer 配置首选模型和提供商。

Bug Fixes:
- 通过规范化运行时配置中的提供商键，并且仅为匹配到的提供商传递密钥保管库，修复 persona writer 的提供商选择问题。

Tests:
- 添加测试，用于验证 persona writer 在运行时提供商解析时正确传入首选模型和提供商。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Support preferred model/provider configuration for the persona writer and ensure it uses the correct provider key vaults during runtime resolution.

New Features:
- Allow configuring preferred models and providers for the persona writer via environment variables and global memory extraction config.

Bug Fixes:
- Fix persona writer provider selection by normalizing runtime config provider keys and only passing key vaults for the matched provider.

Tests:
- Add a test to verify persona writer passes preferred models and providers into runtime provider resolution.

</details>