### PR TITLE
💄 style: add `spark-x2-flash` support

### DIFF
--- a/packages/model-bank/src/aiModels/spark.ts
+++ b/packages/model-bank/src/aiModels/spark.ts
@@ -7,12 +7,37 @@ const sparkChatModels: AIChatModelCard[] = [
       reasoning: true,
       search: true,
     },
+    config: {
+      deploymentName: 'spark-x',
+    },
+    contextWindowTokens: 262_144,
+    description:
+      'Spark X2-Flash adopts an MoE (Mixture of Experts) architecture with 30 billion total parameters and supports up to a 256K context window. It claims significant improvements in agentic and coding capabilities, and was trained on a cluster of Ascend 910B AI processors.',
+    displayName: 'Spark X2 Flash',
+    enabled: true,
+    id: 'spark-x2-flash',
+    maxOutput: 262_144,
+    settings: {
+      extendParams: ['thinking'],
+      searchImpl: 'params',
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+      search: true,
+    },
+    config: {
+      deploymentName: 'spark-x',
+    },
     contextWindowTokens: 131_072,
     description:
       'X2 Capabilities Overview: 1. Introduces dynamic adjustment of reasoning mode, controlled via the `thinking` field. 2. Expanded context length: 64K input tokens and 128K output tokens. 3. Supports Function Call functionality.',
     displayName: 'Spark X2',
     enabled: true,
-    id: 'spark-x',
+    id: 'spark-x2',
     maxOutput: 131_072,
     settings: {
       extendParams: ['thinking'],
@@ -26,11 +51,14 @@ const sparkChatModels: AIChatModelCard[] = [
       reasoning: true,
       search: true,
     },
+    config: {
+      deploymentName: 'spark-x',
+    },
     contextWindowTokens: 65_535,
     description:
       'X1.5 updates: (1) adds dynamic thinking mode controlled by the `thinking` field; (2) larger context length with 64K input and 64K output; (3) supports FunctionCall.',
     displayName: 'Spark X1.5',
-    id: 'x1',
+    id: 'spark-x1.5',
     maxOutput: 65_535,
     settings: {
       extendParams: ['thinking'],

--- a/packages/model-bank/src/modelProviders/spark.ts
+++ b/packages/model-bank/src/modelProviders/spark.ts
@@ -17,6 +17,7 @@ const Spark: ModelProviderCard = {
       text: 'smooth',
     },
     sdkType: 'openai',
+    showDeployName: true,
     showModelFetcher: false,
   },
   url: 'https://www.xfyun.cn',

--- a/packages/model-runtime/src/providers/spark/index.test.ts
+++ b/packages/model-runtime/src/providers/spark/index.test.ts
@@ -6,7 +6,7 @@ import { testProvider } from '../../providerTestUtils';
 import { LobeSparkAI, params } from './index';
 
 const provider = ModelProvider.Spark;
-const defaultBaseURL = 'https://spark-api-open.xf-yun.com/v2';
+const defaultBaseURL = 'https://spark-api-open.xf-yun.com/v1';
 
 testProvider({
   Runtime: LobeSparkAI,

--- a/packages/model-runtime/src/providers/spark/index.ts
+++ b/packages/model-runtime/src/providers/spark/index.ts
@@ -29,9 +29,11 @@ export const params = {
   baseURL: 'https://spark-api-open.xf-yun.com/v1',
   chatCompletion: {
     handlePayload: (payload: ChatStreamPayload, options) => {
-      const { enabledSearch, thinking, tools, ...rest } = payload;
+      const { deploymentName, enabledSearch, model, thinking, tools, ...rest } = payload;
 
-      const baseURL = getBaseURLByModel(payload.model);
+      const requestModel = deploymentName ?? model;
+
+      const baseURL = getBaseURLByModel(model);
       if (options) options.baseURL = baseURL;
 
       const sparkTools = enabledSearch
@@ -52,6 +54,7 @@ export const params = {
 
       return {
         ...rest,
+        model: requestModel,
         thinking: { type: thinking?.type },
         tools: sparkTools,
       } as any;

--- a/packages/model-runtime/src/providers/spark/index.ts
+++ b/packages/model-runtime/src/providers/spark/index.ts
@@ -6,18 +6,27 @@ import { SparkAIStream, transformSparkResponseToStream } from '../../core/stream
 import type { ChatStreamPayload } from '../../types';
 
 const getBaseURLByModel = (model: string): string => {
-  const v1Regex = /^(?:lite|generalv3|pro-128k|generalv3\.5|max-32k|4\.0Ultra)$/i;
+  switch (model) {
+    case 'spark-x2-flash': {
+      return 'https://spark-api-open.xf-yun.com/agent/v1';
+    }
 
-  // Legacy models via v1 endpoint
-  if (v1Regex.test(model)) {
-    return 'https://spark-api-open.xf-yun.com/v1';
+    case 'spark-x2': {
+      return 'https://spark-api-open.xf-yun.com/x2';
+    }
+
+    case 'spark-x1.5': {
+      return 'https://spark-api-open.xf-yun.com/v2';
+    }
+
+    default: {
+      return 'https://spark-api-open.xf-yun.com/v1';
+    }
   }
-
-  return 'https://spark-api-open.xf-yun.com/v2';
 };
 
 export const params = {
-  baseURL: 'https://spark-api-open.xf-yun.com/v2',
+  baseURL: 'https://spark-api-open.xf-yun.com/v1',
   chatCompletion: {
     handlePayload: (payload: ChatStreamPayload, options) => {
       const { enabledSearch, thinking, tools, ...rest } = payload;

--- a/src/server/globalConfig/index.ts
+++ b/src/server/globalConfig/index.ts
@@ -43,6 +43,9 @@ export const getServerGlobalConfig = async () => {
         enabledKey: 'ENABLED_AZURE_OPENAI',
         withDeploymentName: true,
       },
+      azureai: {
+        withDeploymentName: true,
+      },
       bedrock: {
         enabledKey: 'ENABLED_AWS_BEDROCK',
         modelListKey: 'AWS_BEDROCK_MODEL_LIST',
@@ -53,6 +56,9 @@ export const getServerGlobalConfig = async () => {
       giteeai: {
         enabledKey: 'ENABLED_GITEE_AI',
         modelListKey: 'GITEE_AI_MODEL_LIST',
+      },
+      kimicodingplan: {
+        withDeploymentName: true,
       },
       lmstudio: {
         fetchOnClient: isDesktop ? false : undefined,
@@ -67,11 +73,17 @@ export const getServerGlobalConfig = async () => {
       qwen: {
         withDeploymentName: true,
       },
+      spark: {
+        withDeploymentName: true,
+      },
       tencentcloud: {
         enabledKey: 'ENABLED_TENCENT_CLOUD',
         modelListKey: 'TENCENT_CLOUD_MODEL_LIST',
       },
       volcengine: {
+        withDeploymentName: true,
+      },
+      volcenginecodingplan: {
         withDeploymentName: true,
       },
     }),

--- a/src/services/chat/index.ts
+++ b/src/services/chat/index.ts
@@ -63,7 +63,9 @@ const providersWithDeploymentName = new Set<string>([
   ModelProvider.AzureAI,
   ModelProvider.KimiCodingPlan,
   ModelProvider.Qwen,
+  ModelProvider.Spark,
   ModelProvider.Volcengine,
+  ModelProvider.VolcengineCodingPlan,
 ]);
 interface GetChatCompletionPayload extends Partial<Omit<ChatStreamPayload, 'messages'>> {
   agentId?: string;
@@ -360,7 +362,8 @@ class ChatService {
       ? findDeploymentName(model, provider)
       : undefined;
     const shouldUseDeploymentField =
-      provider === ModelProvider.Azure && responsesAPIModels.has(model);
+      (provider === ModelProvider.Azure && responsesAPIModels.has(model)) ||
+      provider === ModelProvider.Spark;
 
     if (!shouldUseDeploymentField && deploymentName) {
       model = deploymentName;


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

为 Spark X2 Flash 提供支持，并使 Spark 提供方的路由和元数据与新的及现有的 Spark 模型变体保持一致。

新功能：
- 在模型库中引入 Spark X2 Flash 聊天模型，提供扩展的上下文长度、能力和元数据。

增强：
- 更新 Spark X2 和 X1.5 的模型标识符、部署配置以及显示元数据，以在各 Spark 变体之间保持一致性。
- 将 Spark 运行时请求路由到模型特定的基础 URL，并将默认的 Spark 基础 URL 更改为 v1 端点。
- 在提供方配置 UI 中公开 Spark 部署名称。

测试：
- 调整 Spark 提供方测试，以反映新的默认基础 URL 路由行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for Spark X2 Flash and align Spark provider routing and metadata with new and existing Spark model variants.

New Features:
- Introduce Spark X2 Flash chat model with extended context, capabilities, and metadata in the model bank.

Enhancements:
- Update Spark X2 and X1.5 model identifiers, deployment configuration, and display metadata for consistency across Spark variants.
- Route Spark runtime requests to model-specific base URLs and change the default Spark base URL to the v1 endpoint.
- Expose the Spark deployment name in the provider configuration UI.

Tests:
- Adjust Spark provider tests to reflect the new default base URL routing behavior.

</details>