### PR TITLE
✨ feat(task): auto-ensure qstash schedule

### DIFF
--- a/src/server/workflows-hono/index.ts
+++ b/src/server/workflows-hono/index.ts
@@ -3,8 +3,13 @@ import { Hono } from 'hono';
 import agentSignalApp from './agent-signal';
 import memoryUserMemoryApp from './memory-user-memory';
 import taskApp from './task';
+import { ensureTaskDispatchSchedule } from './task/bootstrap';
 
 const app = new Hono().basePath('/api/workflows');
+
+void ensureTaskDispatchSchedule().catch((error) => {
+  console.error('[workflows-hono] Failed to ensure task dispatch schedule:', error);
+});
 
 app.route('/agent-signal', agentSignalApp);
 app.route('/memory-user-memory', memoryUserMemoryApp);

--- a/src/server/workflows-hono/task/bootstrap.test.ts
+++ b/src/server/workflows-hono/task/bootstrap.test.ts
@@ -1,0 +1,72 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ensureTaskDispatchSchedule } from './bootstrap';
+
+describe('ensureTaskDispatchSchedule', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('creates the 10-minute dispatch schedule with a stable scheduleId', async () => {
+    const create = vi.fn().mockResolvedValue({ scheduleId: 'task-schedule-dispatch' });
+
+    await ensureTaskDispatchSchedule({
+      appUrl: 'https://app.example.com/',
+      enabled: true,
+      qstash: {
+        schedules: {
+          create,
+        },
+      },
+    });
+
+    expect(create).toHaveBeenCalledWith({
+      body: JSON.stringify({}),
+      cron: '*/10 * * * *',
+      destination: 'https://app.example.com/api/workflows/task/schedule-dispatch',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      label: 'task-schedule-dispatch',
+      method: 'POST',
+      scheduleId: 'task-schedule-dispatch',
+    });
+  });
+
+  it('skips schedule creation when task queue runtime is disabled', async () => {
+    const create = vi.fn();
+
+    await ensureTaskDispatchSchedule({
+      appUrl: 'https://app.example.com',
+      enabled: false,
+      qstash: {
+        schedules: {
+          create,
+        },
+      },
+    });
+
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it('trims the trailing slash from the app url', async () => {
+    const create = vi.fn().mockResolvedValue({ scheduleId: 'task-schedule-dispatch' });
+
+    await ensureTaskDispatchSchedule({
+      appUrl: 'https://app.example.com/',
+      enabled: true,
+      qstash: {
+        schedules: {
+          create,
+        },
+      },
+    });
+
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        destination: 'https://app.example.com/api/workflows/task/schedule-dispatch',
+      }),
+    );
+  });
+});

--- a/src/server/workflows-hono/task/bootstrap.ts
+++ b/src/server/workflows-hono/task/bootstrap.ts
@@ -1,0 +1,85 @@
+import debug from 'debug';
+
+import { appEnv } from '@/envs/app';
+import { qstashClient } from '@/libs/qstash';
+
+const log = debug('lobe-server:workflows:task:bootstrap');
+
+const TASK_DISPATCH_SCHEDULE_ID = 'task-schedule-dispatch';
+const TASK_DISPATCH_CRON = '*/10 * * * *';
+const TASK_DISPATCH_PATH = '/api/workflows/task/schedule-dispatch';
+
+interface TaskDispatchScheduleCreateRequest {
+  body?: BodyInit;
+  cron: string;
+  destination: string;
+  headers?: HeadersInit;
+  label?: string;
+  method?: 'POST';
+  scheduleId?: string;
+}
+
+interface TaskDispatchQStashClient {
+  schedules: {
+    create: (request: TaskDispatchScheduleCreateRequest) => Promise<{ scheduleId: string }>;
+  };
+}
+
+export interface EnsureTaskDispatchScheduleOptions {
+  appUrl?: string;
+  enabled?: boolean;
+  qstash?: TaskDispatchQStashClient;
+}
+
+let ensureDefaultSchedulePromise: Promise<void> | null = null;
+
+const ensureTaskDispatchScheduleInternal = async (
+  options: EnsureTaskDispatchScheduleOptions,
+): Promise<void> => {
+  const enabled = options.enabled ?? appEnv.enableQueueAgentRuntime;
+  if (!enabled) return;
+
+  const appUrl = options.appUrl ?? appEnv.APP_URL ?? appEnv.INTERNAL_APP_URL;
+  if (!appUrl) {
+    throw new Error('APP_URL is required to create the task dispatch QStash schedule');
+  }
+
+  const client = options.qstash ?? qstashClient;
+  const destination = `${appUrl.replace(/\/$/, '')}${TASK_DISPATCH_PATH}`;
+
+  await client.schedules.create({
+    body: JSON.stringify({}),
+    cron: TASK_DISPATCH_CRON,
+    destination,
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    label: TASK_DISPATCH_SCHEDULE_ID,
+    method: 'POST',
+    scheduleId: TASK_DISPATCH_SCHEDULE_ID,
+  });
+
+  log(
+    'Ensured task dispatch schedule id=%s cron=%s destination=%s',
+    TASK_DISPATCH_SCHEDULE_ID,
+    TASK_DISPATCH_CRON,
+    destination,
+  );
+};
+
+export const ensureTaskDispatchSchedule = (
+  options: EnsureTaskDispatchScheduleOptions = {},
+): Promise<void> => {
+  if (Object.keys(options).length > 0) {
+    return ensureTaskDispatchScheduleInternal(options);
+  }
+
+  if (ensureDefaultSchedulePromise) return ensureDefaultSchedulePromise;
+
+  ensureDefaultSchedulePromise = ensureTaskDispatchScheduleInternal(options).catch((error) => {
+    ensureDefaultSchedulePromise = null;
+    throw error;
+  });
+
+  return ensureDefaultSchedulePromise;
+};


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

## Summary by Sourcery

确保在 workflows Hono 应用启动时，自动创建用于任务派发的循环 QStash 调度。

New Features:
- 添加引导工具，根据应用环境配置，设置周期性任务派发的 QStash 调度。
- 在 workflows 服务器启动时自动初始化任务派发调度，并在失败时记录错误日志。

Tests:
- 添加单元测试，用于验证任务派发调度引导行为及配置处理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure a recurring QStash schedule is automatically created for task dispatch when the workflows Hono app starts.

New Features:
- Add bootstrapping utility to configure a periodic task dispatch QStash schedule based on application environment settings.
- Automatically initialize the task dispatch schedule on workflows server startup with error logging for failures.

Tests:
- Add unit tests for the task dispatch schedule bootstrap behavior and configuration handling.

</details>